### PR TITLE
fix: Test failure when run on linux machine

### DIFF
--- a/apps/desktop/src-tauri/src/platform/mod.rs
+++ b/apps/desktop/src-tauri/src/platform/mod.rs
@@ -1,11 +1,9 @@
-#[cfg(target_os = "macos")]
-pub mod macos;
-
-#[cfg(target_os = "windows")]
-pub mod windows;
-
 #[cfg(target_os = "linux")]
 pub mod linux;
+#[cfg(any(test, target_os = "macos"))]
+pub mod macos;
+#[cfg(target_os = "windows")]
+pub mod windows;
 
 use crate::agent::tool_router::ToolRouter;
 

--- a/apps/desktop/src-tauri/src/playbooks.rs
+++ b/apps/desktop/src-tauri/src/playbooks.rs
@@ -664,7 +664,7 @@ mod tests {
 
         // Build the real tool router to get all registered tool names.
         let mut router = ToolRouter::new();
-        crate::platform::register_platform_tools(&mut router);
+        crate::platform::macos::register_tools(&mut router);
         let tool_defs = router.tool_definitions();
         let tool_names: Vec<&str> = tool_defs.iter().map(|d| d.name.as_str()).collect();
 


### PR DESCRIPTION
The issue with the fixed unit test is that it assumes that the system is always a `macos` machine. When compiled/run for linux, the router will never load in mac_ping or others. This makes the route an invariant for the purpoeses of the test.