### PR TITLE
fix: restore title bar window dragging

### DIFF
--- a/apps/desktop/src/components/MainTitleBar.tsx
+++ b/apps/desktop/src/components/MainTitleBar.tsx
@@ -1,3 +1,5 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import type { MouseEvent } from "react";
 import { useSessionStore } from "../stores/sessionStore";
 
 const isMac = navigator.platform.startsWith("Mac");
@@ -7,6 +9,13 @@ export function MainTitleBar() {
   const toggleSidebar = useSessionStore((s) => s.toggleSidebar);
   const toggleSettings = useSessionStore((s) => s.toggleSettings);
   const settingsOpen = useSessionStore((s) => s.settingsOpen);
+
+  const startWindowDrag = (e: MouseEvent<HTMLDivElement>) => {
+    if ((e.target as HTMLElement).closest("button")) {
+      return;
+    }
+    getCurrentWindow().startDragging().catch(() => {});
+  };
   // On macOS, pad left to clear native traffic lights (76px).
   // Title bar is outside the zoom container, so no compensation needed.
   const paddingLeft = isMac ? 76 : 12;
@@ -16,6 +25,7 @@ export function MainTitleBar() {
       className="flex items-center justify-between h-[36px] pr-3 flex-shrink-0 select-none"
       style={{ paddingLeft }}
       data-tauri-drag-region=""
+      onMouseDown={startWindowDrag}
     >
       {/* Left: Sidebar toggle (next to traffic lights on Mac) */}
       <button

--- a/apps/desktop/src/components/ui.test.tsx
+++ b/apps/desktop/src/components/ui.test.tsx
@@ -13,6 +13,12 @@ vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn(() => Promise.resolve(() => {})),
 }));
+const startDraggingMock = vi.fn().mockResolvedValue(undefined);
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: vi.fn(() => ({
+    startDragging: startDraggingMock,
+  })),
+}));
 vi.mock("../lib/tauri-commands", () => ({
   listKnowledge: vi.fn().mockResolvedValue([]),
   listSessions: vi.fn().mockResolvedValue([]),
@@ -75,6 +81,7 @@ const SESSION_WITH_CHANGES: SessionRecord = {
 afterEach(() => cleanup());
 
 beforeEach(() => {
+  startDraggingMock.mockClear();
   useSessionStore.setState({
     changes: [],
     changeLogOpen: false,
@@ -85,6 +92,7 @@ beforeEach(() => {
     pendingApproval: null,
     knowledgeOpen: false,
     settingsOpen: false,
+    sidebarOpen: true,
   });
   useChatStore.setState({ messages: [] });
   vi.clearAllMocks();
@@ -105,6 +113,27 @@ describe("MainTitleBar", () => {
     useSessionStore.setState({ sidebarOpen: false });
     render(<MainTitleBar />);
     screen.getByTitle("Show sidebar");
+  });
+
+  it("starts dragging when pressing empty title bar space", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<MainTitleBar />);
+
+    await user.pointer({
+      target: container.firstElementChild as HTMLElement,
+      keys: "[MouseLeft]",
+    });
+
+    expect(startDraggingMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start dragging when pressing a title bar button", async () => {
+    const user = userEvent.setup();
+    render(<MainTitleBar />);
+
+    await user.click(screen.getByTitle("Hide sidebar"));
+
+    expect(startDraggingMock).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
### Motivation
- Clicking the title bar empty space did not start window dragging, preventing users from moving the app window by the title area.
- The existing `data-tauri-drag-region` alone was insufficient in all environments, so an explicit drag-start was needed while preserving button interactivity.

### Description
- Add explicit `onMouseDown` handler on `MainTitleBar` that calls `getCurrentWindow().startDragging()` to start a native window drag when clicking empty title-bar space. 
- Guard the drag start so clicks originating from title-bar buttons are ignored by checking `closest("button")` on the event target. 
- Import `getCurrentWindow` and a typed `MouseEvent` in `apps/desktop/src/components/MainTitleBar.tsx` and wire up `startWindowDrag`. 
- Add unit tests in `apps/desktop/src/components/ui.test.tsx` that mock the Tauri window API and verify dragging starts from blank title-bar space and does not start when clicking a title-bar button, and make the test setup deterministic by ensuring `sidebarOpen` is set in `beforeEach`.

### Testing
- Ran TypeScript type check with `npx tsc --noEmit` in `apps/desktop` and it succeeded. 
- Ran unit tests with `npx vitest run src/components/ui.test.tsx` in `apps/desktop` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac597a0d788327872f50cd72c6532d)