### PR TITLE
feat: card-based Knowledge panel with tabs, playbook markdown, and artwork prompt generator

### DIFF
--- a/apps/desktop/src-tauri/src/knowledge.rs
+++ b/apps/desktop/src-tauri/src/knowledge.rs
@@ -85,9 +85,7 @@ pub fn safe_resolve(knowledge_dir: &Path, relative: &str) -> Result<PathBuf> {
     }
 
     // Reconstruct the final path using the canonical parent + filename.
-    let filename = joined
-        .file_name()
-        .context("Missing filename")?;
+    let filename = joined.file_name().context("Missing filename")?;
     Ok(canonical_parent.join(filename))
 }
 
@@ -99,6 +97,30 @@ pub struct KnowledgeEntry {
     pub filename: String,
     pub path: String,
     pub title: String,
+    pub playbook_type: Option<String>,
+}
+
+fn extract_playbook_type(content: &str) -> Option<String> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return None;
+    }
+
+    let after_first = &trimmed[3..];
+    let end = after_first.find("\n---")?;
+    let yaml_block = &after_first[..end];
+
+    for line in yaml_block.lines() {
+        let line = line.trim();
+        if let Some(value) = line.strip_prefix("type:") {
+            let kind = value.trim();
+            if !kind.is_empty() {
+                return Some(kind.to_string());
+            }
+        }
+    }
+
+    None
 }
 
 /// Extract the title from the first `# ` heading line, or derive from filename.
@@ -113,9 +135,7 @@ fn extract_title(content: &str, filename: &str) -> String {
         }
     }
     // Derive from filename: replace dashes with spaces, title-case first letter.
-    let derived = filename
-        .trim_end_matches(".md")
-        .replace('-', " ");
+    let derived = filename.trim_end_matches(".md").replace('-', " ");
     let mut chars = derived.chars();
     match chars.next() {
         None => "Untitled".to_string(),
@@ -124,7 +144,10 @@ fn extract_title(content: &str, filename: &str) -> String {
 }
 
 /// List all knowledge files, optionally filtered by category.
-pub fn list_knowledge_tree(knowledge_dir: &Path, category: Option<&str>) -> Result<Vec<KnowledgeEntry>> {
+pub fn list_knowledge_tree(
+    knowledge_dir: &Path,
+    category: Option<&str>,
+) -> Result<Vec<KnowledgeEntry>> {
     let mut entries = Vec::new();
 
     let dirs_to_scan: Vec<PathBuf> = if let Some(cat) = category {
@@ -167,11 +190,17 @@ pub fn list_knowledge_tree(knowledge_dir: &Path, category: Option<&str>) -> Resu
                 let rel_path = format!("{}/{}", cat_name, fname);
                 let content = std::fs::read_to_string(file_entry.path()).unwrap_or_default();
                 let title = extract_title(&content, &fname);
+                let playbook_type = if cat_name == "playbooks" {
+                    extract_playbook_type(&content).or_else(|| Some("user".to_string()))
+                } else {
+                    None
+                };
                 entries.push(KnowledgeEntry {
                     category: cat_name.clone(),
                     filename: fname,
                     path: rel_path,
                     title,
+                    playbook_type,
                 });
             }
         }
@@ -255,9 +284,18 @@ impl Tool for WriteKnowledgeTool {
     }
 
     async fn execute(&self, input: &Value) -> Result<ToolResult> {
-        let category = input.get("category").and_then(|v| v.as_str()).context("Missing 'category'")?;
-        let filename = input.get("filename").and_then(|v| v.as_str()).context("Missing 'filename'")?;
-        let content = input.get("content").and_then(|v| v.as_str()).context("Missing 'content'")?;
+        let category = input
+            .get("category")
+            .and_then(|v| v.as_str())
+            .context("Missing 'category'")?;
+        let filename = input
+            .get("filename")
+            .and_then(|v| v.as_str())
+            .context("Missing 'filename'")?;
+        let content = input
+            .get("content")
+            .and_then(|v| v.as_str())
+            .context("Missing 'content'")?;
 
         let slug = slugify(filename);
         let rel_path = format!("{}/{}.md", slugify(category), slug);
@@ -317,7 +355,10 @@ impl Tool for SearchKnowledgeTool {
     }
 
     async fn execute(&self, input: &Value) -> Result<ToolResult> {
-        let query = input.get("query").and_then(|v| v.as_str()).context("Missing 'query'")?;
+        let query = input
+            .get("query")
+            .and_then(|v| v.as_str())
+            .context("Missing 'query'")?;
         let category = input.get("category").and_then(|v| v.as_str());
 
         let query_lower = query.to_lowercase();
@@ -426,7 +467,10 @@ impl Tool for ReadKnowledgeTool {
     }
 
     async fn execute(&self, input: &Value) -> Result<ToolResult> {
-        let path = input.get("path").and_then(|v| v.as_str()).context("Missing 'path'")?;
+        let path = input
+            .get("path")
+            .and_then(|v| v.as_str())
+            .context("Missing 'path'")?;
         let full_path = safe_resolve(&self.knowledge_dir, path)?;
 
         let content = std::fs::read_to_string(&full_path)
@@ -501,12 +545,14 @@ impl Tool for ListKnowledgeTool {
 
         let data: Vec<Value> = entries
             .iter()
-            .map(|e| json!({
-                "category": e.category,
-                "filename": e.filename,
-                "path": e.path,
-                "title": e.title,
-            }))
+            .map(|e| {
+                json!({
+                    "category": e.category,
+                    "filename": e.filename,
+                    "path": e.path,
+                    "title": e.title,
+                })
+            })
             .collect();
 
         Ok(ToolResult::read_only(
@@ -520,10 +566,7 @@ impl Tool for ListKnowledgeTool {
 
 /// Migrate existing artifacts from SQLite to markdown files.
 /// Called by journal migration 4.
-pub fn migrate_artifacts_to_files(
-    conn: &rusqlite::Connection,
-    knowledge_dir: &Path,
-) -> Result<()> {
+pub fn migrate_artifacts_to_files(conn: &rusqlite::Connection, knowledge_dir: &Path) -> Result<()> {
     // Check if the artifacts table exists.
     let table_exists: bool = conn
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='artifacts'")
@@ -534,9 +577,8 @@ pub fn migrate_artifacts_to_files(
         return Ok(());
     }
 
-    let mut stmt = conn.prepare(
-        "SELECT category, title, content FROM artifacts ORDER BY updated_at ASC",
-    )?;
+    let mut stmt =
+        conn.prepare("SELECT category, title, content FROM artifacts ORDER BY updated_at ASC")?;
 
     let rows = stmt.query_map([], |row| {
         Ok((
@@ -586,8 +628,7 @@ pub fn delete_knowledge_file(knowledge_dir: &Path, relative: &str) -> Result<()>
     if !full_path.exists() {
         anyhow::bail!("File not found: {}", relative);
     }
-    std::fs::remove_file(&full_path)
-        .with_context(|| format!("Failed to delete: {}", relative))?;
+    std::fs::remove_file(&full_path).with_context(|| format!("Failed to delete: {}", relative))?;
     Ok(())
 }
 
@@ -611,7 +652,10 @@ mod tests {
 
     #[test]
     fn test_slugify_special_chars() {
-        assert_eq!(slugify("Slow WiFi fixed (DNS change)"), "slow-wifi-fixed-dns-change");
+        assert_eq!(
+            slugify("Slow WiFi fixed (DNS change)"),
+            "slow-wifi-fixed-dns-change"
+        );
     }
 
     #[test]
@@ -660,7 +704,11 @@ mod tests {
     fn test_list_knowledge_tree_with_files() {
         let (_tmp, kdir) = setup();
         std::fs::write(kdir.join("devices/printer.md"), "# HP LaserJet\n\nDetails").unwrap();
-        std::fs::write(kdir.join("issues/slow-wifi.md"), "# Slow WiFi Fixed\n\nChanged DNS").unwrap();
+        std::fs::write(
+            kdir.join("issues/slow-wifi.md"),
+            "# Slow WiFi Fixed\n\nChanged DNS",
+        )
+        .unwrap();
 
         let entries = list_knowledge_tree(&kdir, None).unwrap();
         assert_eq!(entries.len(), 2);
@@ -678,6 +726,22 @@ mod tests {
         let entries = list_knowledge_tree(&kdir, Some("devices")).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].title, "Printer");
+    }
+
+    #[test]
+    fn test_list_knowledge_tree_sets_playbook_type() {
+        let (_tmp, kdir) = setup();
+        let content = "---
+name: Network Diagnostics
+description: Diagnose network issues
+type: system
+---
+# Network";
+        std::fs::write(kdir.join("playbooks/network.md"), content).unwrap();
+
+        let entries = list_knowledge_tree(&kdir, Some("playbooks")).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].playbook_type.as_deref(), Some("system"));
     }
 
     #[test]
@@ -701,12 +765,18 @@ mod tests {
 
     #[test]
     fn test_extract_title_from_heading() {
-        assert_eq!(extract_title("# My Title\n\nContent", "file.md"), "My Title");
+        assert_eq!(
+            extract_title("# My Title\n\nContent", "file.md"),
+            "My Title"
+        );
     }
 
     #[test]
     fn test_extract_title_from_filename() {
-        assert_eq!(extract_title("No heading here", "my-cool-file.md"), "My cool file");
+        assert_eq!(
+            extract_title("No heading here", "my-cool-file.md"),
+            "My cool file"
+        );
     }
 
     #[test]
@@ -748,8 +818,16 @@ mod tests {
     #[tokio::test]
     async fn test_search_knowledge_tool() {
         let (_tmp, kdir) = setup();
-        std::fs::write(kdir.join("devices/printer.md"), "# HP LaserJet\n\nModel M404n").unwrap();
-        std::fs::write(kdir.join("network/wifi.md"), "# WiFi Config\n\nDNS: 8.8.8.8").unwrap();
+        std::fs::write(
+            kdir.join("devices/printer.md"),
+            "# HP LaserJet\n\nModel M404n",
+        )
+        .unwrap();
+        std::fs::write(
+            kdir.join("network/wifi.md"),
+            "# WiFi Config\n\nDNS: 8.8.8.8",
+        )
+        .unwrap();
 
         let tool = SearchKnowledgeTool::new(kdir);
         let input = json!({ "query": "DNS" });
@@ -770,7 +848,11 @@ mod tests {
     #[tokio::test]
     async fn test_read_knowledge_tool() {
         let (_tmp, kdir) = setup();
-        std::fs::write(kdir.join("devices/printer.md"), "# HP LaserJet\n\nDetails here").unwrap();
+        std::fs::write(
+            kdir.join("devices/printer.md"),
+            "# HP LaserJet\n\nDetails here",
+        )
+        .unwrap();
 
         let tool = ReadKnowledgeTool::new(kdir);
         let input = json!({ "path": "devices/printer.md" });

--- a/apps/desktop/src/components/KnowledgePanel.tsx
+++ b/apps/desktop/src/components/KnowledgePanel.tsx
@@ -1,69 +1,180 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo, type ReactElement } from "react";
 import { useSessionStore } from "../stores/sessionStore";
 import * as commands from "../lib/tauri-commands";
 import type { KnowledgeEntry } from "../lib/tauri-commands";
 
-function KnowledgeItem({
+type KnowledgeTab = "builtin" | "yours" | "learned";
+
+function toTitleCase(value: string): string {
+  return value
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function MarkdownView({ content }: { content: string }) {
+  const lines = content.split("\n");
+  const blocks: ReactElement[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (line.trim().startsWith("```") || line.trim().startsWith("~~~")) {
+      const fence = line.trim().slice(0, 3);
+      const codeLines: string[] = [];
+      i += 1;
+      while (i < lines.length && !lines[i].trim().startsWith(fence)) {
+        codeLines.push(lines[i]);
+        i += 1;
+      }
+      blocks.push(
+        <pre
+          key={`code-${i}`}
+          className="bg-bg-secondary/70 border border-border-primary rounded-lg p-4 overflow-x-auto text-sm text-text-primary font-mono"
+        >
+          {codeLines.join("\n")}
+        </pre>,
+      );
+      i += 1;
+      continue;
+    }
+
+    const trimmed = line.trim();
+    if (!trimmed) {
+      i += 1;
+      continue;
+    }
+
+    if (trimmed.startsWith("### ")) {
+      blocks.push(
+        <h3 key={`h3-${i}`} className="text-lg font-semibold text-text-primary mt-6 mb-2">
+          {trimmed.slice(4)}
+        </h3>,
+      );
+      i += 1;
+      continue;
+    }
+
+    if (trimmed.startsWith("## ")) {
+      blocks.push(
+        <h2 key={`h2-${i}`} className="text-xl font-semibold text-text-primary mt-6 mb-2">
+          {trimmed.slice(3)}
+        </h2>,
+      );
+      i += 1;
+      continue;
+    }
+
+    if (trimmed.startsWith("# ")) {
+      blocks.push(
+        <h1 key={`h1-${i}`} className="text-2xl font-semibold text-text-primary mt-6 mb-3">
+          {trimmed.slice(2)}
+        </h1>,
+      );
+      i += 1;
+      continue;
+    }
+
+    if (trimmed.startsWith("- ") || trimmed.startsWith("* ")) {
+      const items: string[] = [];
+      while (i < lines.length) {
+        const l = lines[i].trim();
+        if (l.startsWith("- ") || l.startsWith("* ")) {
+          items.push(l.slice(2));
+          i += 1;
+          continue;
+        }
+        break;
+      }
+      blocks.push(
+        <ul key={`ul-${i}`} className="list-disc pl-6 space-y-1 text-text-primary">
+          {items.map((item, idx) => (
+            <li key={idx}>{item}</li>
+          ))}
+        </ul>,
+      );
+      continue;
+    }
+
+    const paragraph: string[] = [trimmed];
+    i += 1;
+    while (i < lines.length) {
+      const next = lines[i].trim();
+      if (
+        !next ||
+        next.startsWith("#") ||
+        next.startsWith("- ") ||
+        next.startsWith("* ") ||
+        next.startsWith("```") ||
+        next.startsWith("~~~")
+      ) {
+        break;
+      }
+      paragraph.push(next);
+      i += 1;
+    }
+
+    blocks.push(
+      <p key={`p-${i}`} className="text-base text-text-primary leading-relaxed">
+        {paragraph.join(" ")}
+      </p>,
+    );
+  }
+
+  return <div className="space-y-3">{blocks}</div>;
+}
+
+function KnowledgeCard({
   entry,
+  icon,
   onSelect,
   onDelete,
 }: {
   entry: KnowledgeEntry;
-  onSelect: (path: string) => void;
+  icon: string;
+  onSelect: (entry: KnowledgeEntry) => void;
   onDelete: (path: string) => void;
 }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
 
   return (
-    <div className="border-b border-border-primary/50 last:border-b-0">
-      <button
-        onClick={() => onSelect(entry.path)}
-        className="w-full px-6 py-3 text-left hover:bg-bg-tertiary/30 transition-colors cursor-pointer"
-      >
-        <p className="text-base text-text-primary leading-snug">
-          {entry.title}
-        </p>
-        <div className="flex items-center gap-2 mt-1">
-          <span className="text-xs text-text-muted font-mono">
-            {entry.path}
-          </span>
-          <span className="ml-auto">
-            {confirmDelete ? (
-              <>
-                <span
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDelete(entry.path);
-                    setConfirmDelete(false);
-                  }}
-                  className="text-xs text-accent-red font-medium cursor-pointer"
-                >
-                  Confirm
-                </span>
-                <span
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setConfirmDelete(false);
-                  }}
-                  className="text-xs text-text-muted cursor-pointer ml-2"
-                >
-                  Cancel
-                </span>
-              </>
-            ) : (
-              <span
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setConfirmDelete(true);
-                }}
-                className="text-xs text-text-muted hover:text-accent-red transition-colors cursor-pointer"
-              >
-                Delete
-              </span>
-            )}
-          </span>
+    <div className="rounded-xl border border-border-primary bg-bg-secondary/50 p-4 hover:bg-bg-tertiary/20 transition-colors">
+      <button onClick={() => onSelect(entry)} className="w-full text-left cursor-pointer">
+        <div className="h-24 rounded-lg bg-bg-tertiary/50 border border-border-primary/60 flex items-center justify-center text-3xl mb-3">
+          {icon}
         </div>
+        <p className="text-base text-text-primary font-medium line-clamp-2">{entry.title}</p>
+        <p className="text-xs text-text-muted font-mono mt-1 truncate">{entry.path}</p>
       </button>
+      <div className="flex justify-end mt-3 text-xs">
+        {confirmDelete ? (
+          <>
+            <button
+              onClick={() => {
+                onDelete(entry.path);
+                setConfirmDelete(false);
+              }}
+              className="text-accent-red font-medium cursor-pointer"
+            >
+              Confirm
+            </button>
+            <button
+              onClick={() => setConfirmDelete(false)}
+              className="text-text-muted ml-2 cursor-pointer"
+            >
+              Cancel
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={() => setConfirmDelete(true)}
+            className="text-text-muted hover:text-accent-red transition-colors cursor-pointer"
+          >
+            Delete
+          </button>
+        )}
+      </div>
     </div>
   );
 }
@@ -71,8 +182,9 @@ function KnowledgeItem({
 export function KnowledgeView() {
   const activeView = useSessionStore((s) => s.activeView);
   const [entries, setEntries] = useState<KnowledgeEntry[]>([]);
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [selectedEntry, setSelectedEntry] = useState<KnowledgeEntry | null>(null);
   const [fileContent, setFileContent] = useState<string>("");
+  const [activeTab, setActiveTab] = useState<KnowledgeTab>("builtin");
 
   const loadEntries = useCallback(async () => {
     try {
@@ -86,15 +198,16 @@ export function KnowledgeView() {
   useEffect(() => {
     if (activeView === "knowledge") {
       loadEntries();
-      setSelectedPath(null);
+      setSelectedEntry(null);
+      setActiveTab("builtin");
     }
   }, [activeView, loadEntries]);
 
-  const handleSelect = useCallback(async (path: string) => {
+  const handleSelect = useCallback(async (entry: KnowledgeEntry) => {
     try {
-      const content = await commands.readKnowledgeFile(path);
+      const content = await commands.readKnowledgeFile(entry.path);
       setFileContent(content);
-      setSelectedPath(path);
+      setSelectedEntry(entry);
     } catch (err) {
       console.error("Failed to read knowledge file:", err);
     }
@@ -104,39 +217,38 @@ export function KnowledgeView() {
     async (path: string) => {
       try {
         await commands.deleteKnowledgeFile(path);
-        setEntries(entries.filter((e) => e.path !== path));
-        if (selectedPath === path) {
-          setSelectedPath(null);
-        }
+        setEntries((prev) => prev.filter((e) => e.path !== path));
+        setSelectedEntry((current) => (current?.path === path ? null : current));
       } catch (err) {
         console.error("Failed to delete knowledge file:", err);
       }
     },
-    [entries, selectedPath],
+    [],
   );
 
-  const handleBack = useCallback(() => {
-    setSelectedPath(null);
-  }, []);
-
-  // Group entries by category.
-  const grouped: Record<string, KnowledgeEntry[]> = {};
-  for (const entry of entries) {
-    if (!grouped[entry.category]) {
-      grouped[entry.category] = [];
+  const visibleEntries = useMemo(() => {
+    if (activeTab === "builtin") {
+      return entries.filter(
+        (entry) => entry.category === "playbooks" && (entry.playbook_type ?? "user") === "system",
+      );
     }
-    grouped[entry.category].push(entry);
-  }
-  const categories = Object.keys(grouped).sort();
+
+    if (activeTab === "yours") {
+      return entries.filter(
+        (entry) => entry.category === "playbooks" && (entry.playbook_type ?? "user") !== "system",
+      );
+    }
+
+    return entries.filter((entry) => entry.category !== "playbooks");
+  }, [activeTab, entries]);
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <div className="flex-1 overflow-y-auto">
-        {selectedPath ? (
-          /* Detail view */
-          <div className="max-w-3xl w-full mx-auto px-6 py-6">
+        {selectedEntry ? (
+          <div className="max-w-4xl w-full mx-auto px-6 py-6">
             <button
-              onClick={handleBack}
+              onClick={() => setSelectedEntry(null)}
               className="flex items-center gap-1.5 text-sm text-text-muted hover:text-text-primary transition-colors cursor-pointer mb-4"
             >
               <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
@@ -144,75 +256,86 @@ export function KnowledgeView() {
               </svg>
               Back to knowledge
             </button>
-            <p className="text-xs text-text-muted font-mono mb-4">
-              {selectedPath}
-            </p>
-            <pre className="text-base text-text-primary whitespace-pre-wrap break-words leading-relaxed font-sans">
-              {fileContent}
-            </pre>
+            <p className="text-xs text-text-muted font-mono mb-4">{selectedEntry.path}</p>
+            {selectedEntry.category === "playbooks" ? (
+              <MarkdownView content={fileContent} />
+            ) : (
+              <pre className="text-base text-text-primary whitespace-pre-wrap break-words leading-relaxed font-sans">
+                {fileContent}
+              </pre>
+            )}
           </div>
         ) : entries.length === 0 ? (
-          /* Empty state */
           <div className="flex flex-col items-center justify-center h-full text-text-muted px-6">
-            <svg
-              width="40"
-              height="40"
-              viewBox="0 0 32 32"
-              fill="none"
-              className="mb-4 opacity-50"
-            >
-              <path
-                d="M6 4H20L26 10V28H6V4Z"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M20 4V10H26"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M10 16H22M10 20H22M10 24H18"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-              />
+            <svg width="40" height="40" viewBox="0 0 32 32" fill="none" className="mb-4 opacity-50">
+              <path d="M6 4H20L26 10V28H6V4Z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+              <path d="M20 4V10H26" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+              <path d="M10 16H22M10 20H22M10 24H18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
             </svg>
-            <p className="text-base text-text-secondary mb-1">
-              No knowledge yet
-            </p>
+            <p className="text-base text-text-secondary mb-1">No knowledge yet</p>
             <p className="text-sm text-text-muted text-center max-w-xs">
-              Noah hasn't learned anything about your system yet.
-              Knowledge will build up as you use the app.
+              Noah hasn't learned anything about your system yet. Knowledge will build up as you use the app.
             </p>
           </div>
         ) : (
-          /* List view */
-          <div className="max-w-3xl w-full mx-auto py-4">
-            <div className="px-6 pb-4">
-              <h1 className="text-2xl font-semibold text-text-primary">Knowledge</h1>
-              <p className="text-sm text-text-muted mt-1">
-                {entries.length} file{entries.length !== 1 ? "s" : ""} across{" "}
-                {categories.length} categor{categories.length !== 1 ? "ies" : "y"}
-              </p>
-            </div>
-            {categories.map((cat) => (
-              <div key={cat}>
-                <div className="px-6 py-2 text-xs font-semibold text-text-secondary">
-                  {cat.charAt(0).toUpperCase() + cat.slice(1)}
-                </div>
-                {grouped[cat].map((entry) => (
-                  <KnowledgeItem
-                    key={entry.path}
-                    entry={entry}
-                    onSelect={handleSelect}
-                    onDelete={handleDelete}
-                  />
-                ))}
+          <div className="max-w-6xl w-full mx-auto py-4 px-6">
+            <div className="flex items-center justify-between pb-4">
+              <div>
+                <h1 className="text-2xl font-semibold text-text-primary">Knowledge</h1>
+                <p className="text-sm text-text-muted mt-1">{entries.length} file{entries.length !== 1 ? "s" : ""}</p>
               </div>
-            ))}
+              <button className="px-4 py-2 rounded-lg border border-border-primary text-sm text-text-primary hover:bg-bg-tertiary/40 transition-colors">
+                + New Knowledge
+              </button>
+            </div>
+
+            <div className="flex items-center gap-2 border-b border-border-primary mb-4">
+              {[
+                { key: "builtin", label: "Builtin" },
+                { key: "yours", label: "Your Playbooks" },
+                { key: "learned", label: "Noah Learned" },
+              ].map((tab) => {
+                const key = tab.key as KnowledgeTab;
+                const active = key === activeTab;
+                return (
+                  <button
+                    key={tab.key}
+                    onClick={() => setActiveTab(key)}
+                    className={`px-3 py-2 text-sm border-b-2 -mb-px cursor-pointer transition-colors ${
+                      active
+                        ? "text-text-primary border-text-primary"
+                        : "text-text-muted border-transparent hover:text-text-primary"
+                    }`}
+                  >
+                    {tab.label}
+                  </button>
+                );
+              })}
+            </div>
+
+            {visibleEntries.length === 0 ? (
+              <p className="text-sm text-text-muted py-8">No entries in this tab yet.</p>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 pb-4">
+                {visibleEntries.map((entry) => {
+                  const icon =
+                    entry.category === "playbooks"
+                      ? (entry.playbook_type ?? "user") === "system"
+                        ? "🧭"
+                        : "📘"
+                      : "🧠";
+                  return (
+                    <KnowledgeCard
+                      key={entry.path}
+                      entry={{ ...entry, title: entry.title || toTitleCase(entry.filename.replace(".md", "")) }}
+                      icon={icon}
+                      onSelect={handleSelect}
+                      onDelete={handleDelete}
+                    />
+                  );
+                })}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/apps/desktop/src/lib/tauri-commands.ts
+++ b/apps/desktop/src/lib/tauri-commands.ts
@@ -50,6 +50,7 @@ export interface KnowledgeEntry {
   filename: string;
   path: string;
   title: string;
+  playbook_type?: string | null;
 }
 
 // ── Tauri Command Wrappers ──

--- a/scripts/generate-playbook-art-prompts.mjs
+++ b/scripts/generate-playbook-art-prompts.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const PLAYBOOK_DIR = path.join(ROOT, "apps", "desktop", "src-tauri", "playbooks");
+const OUTPUT = path.join(ROOT, "scripts", "playbook-art-prompts.json");
+
+function parseFrontmatter(md) {
+  const trimmed = md.trimStart();
+  if (!trimmed.startsWith("---")) {
+    return {};
+  }
+
+  const rest = trimmed.slice(3);
+  const end = rest.indexOf("\n---");
+  if (end === -1) {
+    return {};
+  }
+
+  const yaml = rest.slice(0, end);
+  const meta = {};
+  for (const line of yaml.split("\n")) {
+    const [rawKey, ...rawValue] = line.split(":");
+    if (!rawKey || rawValue.length === 0) continue;
+    const key = rawKey.trim();
+    const value = rawValue.join(":").trim();
+    meta[key] = value;
+  }
+  return meta;
+}
+
+function buildPrompt({ name, description, platform }) {
+  return [
+    `Create a clean, modern illustration card for a troubleshooting playbook titled "${name}".`,
+    `Concept: ${description || "IT diagnostic workflow"}.`,
+    `Platform context: ${platform || "all"}.`,
+    "Style: flat vector, soft gradients, rounded corners, no text in image, subtle depth, product UI aesthetic.",
+    "Composition: one clear hero object + 1-2 supporting objects representing diagnosis and repair.",
+    "Palette: calm tech tones (blue/slate/teal) with a single accent color.",
+    "Export target: 16:9 thumbnail card for desktop app knowledge gallery.",
+  ].join(" ");
+}
+
+async function main() {
+  const files = (await readdir(PLAYBOOK_DIR)).filter((file) => file.endsWith(".md"));
+  const prompts = [];
+
+  for (const file of files) {
+    const full = path.join(PLAYBOOK_DIR, file);
+    const md = await readFile(full, "utf8");
+    const meta = parseFrontmatter(md);
+
+    const normalized = {
+      name: meta.name || file.replace(/\.md$/, "").replace(/-/g, " "),
+      description: meta.description || "",
+      platform: meta.platform || "all",
+    };
+
+    prompts.push({
+      file,
+      ...normalized,
+      prompt: buildPrompt(normalized),
+    });
+  }
+
+  await writeFile(OUTPUT, `${JSON.stringify(prompts, null, 2)}\n`, "utf8");
+  console.log(`Wrote ${prompts.length} prompt(s) to ${path.relative(ROOT, OUTPUT)}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/playbook-art-prompts.json
+++ b/scripts/playbook-art-prompts.json
@@ -1,0 +1,79 @@
+[
+  {
+    "file": "TEMPLATE.md",
+    "name": "TEMPLATE",
+    "description": "",
+    "platform": "all",
+    "prompt": "Create a clean, modern illustration card for a troubleshooting playbook titled \"TEMPLATE\". Concept: IT diagnostic workflow. Platform context: all. Style: flat vector, soft gradients, rounded corners, no text in image, subtle depth, product UI aesthetic. Composition: one clear hero object + 1-2 supporting objects representing diagnosis and repair. Palette: calm tech tones (blue/slate/teal) with a single accent color. Export target: 16:9 thumbnail card for desktop app knowledge gallery."
+  },
+  {
+    "file": "app-doctor.md",
+    "name": "app-doctor",
+    "description": "Fix app crashes, launch failures, and permission issues",
+    "platform": "macos",
+    "prompt": "Create a clean, modern illustration card for a troubleshooting playbook titled \"app-doctor\". Concept: Fix app crashes, launch failures, and permission issues. Platform context: macos. Style: flat vector, soft gradients, rounded corners, no text in image, subtle depth, product UI aesthetic. Composition: one clear hero object + 1-2 supporting objects representing diagnosis and repair. Palette: calm tech tones (blue/slate/teal) with a single accent color. Export target: 16:9 thumbnail card for desktop app knowledge gallery."
+  },
+  {
+    "file": "disk-space-recovery.md",
+    "name": "disk-space-recovery",
+    "description": "Find and reclaim disk space from caches, backups, and hidden consumers",
+    "platform": "macos",
+    "prompt": "Create a clean, modern illustration card for a troubleshooting playbook titled \"disk-space-recovery\". Concept: Find and reclaim disk space from caches, backups, and hidden consumers. Platform context: macos. Style: flat vector, soft gradients, rounded corners, no text in image, subtle depth, product UI aesthetic. Composition: one clear hero object + 1-2 supporting objects representing diagnosis and repair. Palette: calm tech tones (blue/slate/teal) with a single accent color. Export target: 16:9 thumbnail card for desktop app knowledge gallery."
+  },
+  {
+    "file": "network-diagnostics.md",
+    "name": "network-diagnostics",
+    "description": "Systematic connectivity troubleshooting for Wi-Fi, DNS, and internet issues",
+    "platform": "macos",
+    "prompt": "Create a clean, modern illustration card for a troubleshooting playbook titled \"network-diagnostics\". Concept: Systematic connectivity troubleshooting for Wi-Fi, DNS, and internet issues. Platform context: macos. Style: flat vector, soft gradients, rounded corners, no text in image, subtle depth, product UI aesthetic. Composition: one clear hero object + 1-2 supporting objects representing diagnosis and repair. Palette: calm tech tones (blue/slate/teal) with a single accent color. Export target: 16:9 thumbnail card for desktop app knowledge gallery."
+  },
+  {
+    "file": "outlook-troubleshooting.md",
+    "name": "outlook-troubleshooting",
+    "description": "Fix Outlook sync failures, crashes, stuck email, and profile corruption",
+    "platform": "all",
+    "prompt": "Create a clean, modern illustration card for a troubleshooting playbook titled \"outlook-troubleshooting\". Concept: Fix Outlook sync failures, crashes, stuck email, and profile corruption. Platform context: all. Style: flat vector, soft gradients, rounded corners, no text in image, subtle depth, product UI aesthetic. Composition: one clear hero object + 1-2 supporting objects representing diagnosis and repair. Palette: calm tech tones (blue/slate/teal) with a single accent color. Export target: 16:9 thumbnail card for desktop app knowledge gallery."
+  },
+  {
+    "file": "performance-forensics.md",
+    "name": "performance-forensics",
+    "description": "Diagnose slowness, high CPU, memory pressure, and hangs",
+    "platform": "macos",
+    "prompt": "Create a clean, modern illustration card for a troubleshooting playbook titled \"performance-forensics\". Concept: Diagnose slowness, high CPU, memory pressure, and hangs. Platform context: macos. Style: flat vector, soft gradients, rounded corners, no text in image, subtle depth, product UI aesthetic. Composition: one clear hero object + 1-2 supporting objects representing diagnosis and repair. Palette: calm tech tones (blue/slate/teal) with a single accent color. Export target: 16:9 thumbnail card for desktop app knowledge gallery."
+  },
+  {
+    "file": "printer-repair.md",
+    "name": "printer-repair",
+    "description": "Fix stuck print jobs, missing printers, and CUPS issues",
+    "platform": "macos",
+    "prompt": "Create a clean, modern illustration card for a troubleshooting playbook titled \"printer-repair\". Concept: Fix stuck print jobs, missing printers, and CUPS issues. Platform context: macos. Style: flat vector, soft gradients, rounded corners, no text in image, subtle depth, product UI aesthetic. Composition: one clear hero object + 1-2 supporting objects representing diagnosis and repair. Palette: calm tech tones (blue/slate/teal) with a single accent color. Export target: 16:9 thumbnail card for desktop app knowledge gallery."
+  },
+  {
+    "file": "update-troubleshooting.md",
+    "name": "update-troubleshooting",
+    "description": "Fix stuck macOS updates, failed installations, and software update errors",
+    "platform": "macos",
+    "prompt": "Create a clean, modern illustration card for a troubleshooting playbook titled \"update-troubleshooting\". Concept: Fix stuck macOS updates, failed installations, and software update errors. Platform context: macos. Style: flat vector, soft gradients, rounded corners, no text in image, subtle depth, product UI aesthetic. Composition: one clear hero object + 1-2 supporting objects representing diagnosis and repair. Palette: calm tech tones (blue/slate/teal) with a single accent color. Export target: 16:9 thumbnail card for desktop app knowledge gallery."
+  },
+  {
+    "file": "vpn-troubleshooting.md",
+    "name": "vpn-troubleshooting",
+    "description": "Diagnose VPN connection failures, drops, and split-tunnel DNS issues",
+    "platform": "macos",
+    "prompt": "Create a clean, modern illustration card for a troubleshooting playbook titled \"vpn-troubleshooting\". Concept: Diagnose VPN connection failures, drops, and split-tunnel DNS issues. Platform context: macos. Style: flat vector, soft gradients, rounded corners, no text in image, subtle depth, product UI aesthetic. Composition: one clear hero object + 1-2 supporting objects representing diagnosis and repair. Palette: calm tech tones (blue/slate/teal) with a single accent color. Export target: 16:9 thumbnail card for desktop app knowledge gallery."
+  },
+  {
+    "file": "windows-printer-repair.md",
+    "name": "windows-printer-repair",
+    "description": "Fix stuck print jobs, offline printers, and spooler issues on Windows",
+    "platform": "windows",
+    "prompt": "Create a clean, modern illustration card for a troubleshooting playbook titled \"windows-printer-repair\". Concept: Fix stuck print jobs, offline printers, and spooler issues on Windows. Platform context: windows. Style: flat vector, soft gradients, rounded corners, no text in image, subtle depth, product UI aesthetic. Composition: one clear hero object + 1-2 supporting objects representing diagnosis and repair. Palette: calm tech tones (blue/slate/teal) with a single accent color. Export target: 16:9 thumbnail card for desktop app knowledge gallery."
+  },
+  {
+    "file": "windows-update-troubleshooting.md",
+    "name": "windows-update-troubleshooting",
+    "description": "Fix stuck Windows Updates, failed installations, and update service errors",
+    "platform": "windows",
+    "prompt": "Create a clean, modern illustration card for a troubleshooting playbook titled \"windows-update-troubleshooting\". Concept: Fix stuck Windows Updates, failed installations, and update service errors. Platform context: windows. Style: flat vector, soft gradients, rounded corners, no text in image, subtle depth, product UI aesthetic. Composition: one clear hero object + 1-2 supporting objects representing diagnosis and repair. Palette: calm tech tones (blue/slate/teal) with a single accent color. Export target: 16:9 thumbnail card for desktop app knowledge gallery."
+  }
+]


### PR DESCRIPTION
### Motivation
- Improve the Knowledge UI from a flat list to a richer card gallery so playbooks feel discoverable and visual. 
- Present playbooks as `Builtin` vs `Your Playbooks` and surface non-playbook items as `Noah Learned` to match the requested three-tab model. 
- Show playbook content as rendered Markdown blocks instead of raw full-text to improve readability. 

### Description
- Reworked the desktop UI: replaced the list rows with card tiles, added tabs `Builtin`, `Your Playbooks`, and `Noah Learned`, added a `+ New Knowledge` header button, and a playbook detail view that renders Markdown-like blocks via `MarkdownView` in `apps/desktop/src/components/KnowledgePanel.tsx`. 
- Extended knowledge metadata with `playbook_type` across backend and frontend by parsing the playbook frontmatter `type:` and defaulting to `user` for playbooks; changes in `apps/desktop/src-tauri/src/knowledge.rs` and `apps/desktop/src/lib/tauri-commands.ts`. 
- Updated `list_knowledge_tree` to populate `playbook_type` for `playbooks/` entries and added a unit test verifying extraction in `apps/desktop/src-tauri/src/knowledge.rs`. 
- Added a script to generate illustration prompts for playbook artwork: `scripts/generate-playbook-art-prompts.mjs` and the generated catalog `scripts/playbook-art-prompts.json` (prompts follow a consistent fallback naming scheme). 

### Testing
- Ran TypeScript checks with `npx tsc --noEmit` in `apps/desktop` and it passed. 
- Ran the frontend unit suite with `pnpm --filter @itman/desktop test` (Vitest) and all tests passed. 
- Ran `cargo test -p itman-tools` and it passed. 
- Attempted `cargo test --workspace` which failed in this environment due to a missing system dependency (`glib-2.0` / `pkg-config` required by `glib-sys`), so full workspace Rust tests could not complete here. 
- Executed the playbook prompt generator with `node scripts/generate-playbook-art-prompts.mjs` which wrote `scripts/playbook-art-prompts.json`, and exercised the app visually by launching the dev server and capturing a screenshot at `browser:/tmp/codex_browser_invocations/.../artifacts/artifacts/knowledge-panel-cardview.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac5e6afec483278a4f36c428f309c2)