### PR TITLE
fix: ensure scanner schema invariants on startup

### DIFF
--- a/apps/desktop/src-tauri/src/safety/journal.rs
+++ b/apps/desktop/src-tauri/src/safety/journal.rs
@@ -145,7 +145,47 @@ pub fn init_db(path: &str) -> Result<Connection> {
     // Run migrations based on current schema version.
     run_migrations(&conn)?;
 
+    // Ensure critical tables exist even if schema_version was advanced manually
+    // or a prior migration only partially applied.
+    ensure_schema_invariants(&conn)?;
+
     Ok(conn)
+}
+
+fn ensure_schema_invariants(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS system_scan_results (
+            id          INTEGER PRIMARY KEY,
+            scan_type   TEXT NOT NULL,
+            category    TEXT,
+            path        TEXT,
+            key         TEXT,
+            value_num   REAL,
+            value_text  TEXT,
+            metadata    TEXT,
+            stale       INTEGER NOT NULL DEFAULT 0,
+            scanned_at  TEXT NOT NULL,
+            generation  INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_ssr_type ON system_scan_results(scan_type);
+        CREATE INDEX IF NOT EXISTS idx_ssr_type_cat ON system_scan_results(scan_type, category);
+
+        CREATE TABLE IF NOT EXISTS scan_jobs (
+            id              TEXT PRIMARY KEY,
+            scan_type       TEXT NOT NULL,
+            status          TEXT NOT NULL,
+            progress_pct    INTEGER NOT NULL DEFAULT 0,
+            progress_detail TEXT,
+            budget_secs     INTEGER,
+            started_at      TEXT,
+            updated_at      TEXT,
+            completed_at    TEXT,
+            config          TEXT
+        );",
+    )
+    .context("Failed to ensure scanner schema invariants")?;
+
+    Ok(())
 }
 
 fn get_schema_version(conn: &Connection) -> i32 {


### PR DESCRIPTION
### Motivation
- The background scanner can crash on startup with `no such table: system_scan_results` when `schema_version` was already advanced but migration side effects were not applied. 
- Ensure the DB initialization is robust so scanners can rely on required tables and indexes being present.

### Description
- Call `ensure_schema_invariants(&conn)` from `init_db` after `run_migrations` to guarantee critical tables exist on every startup.  
- Add `ensure_schema_invariants` which idempotently creates `system_scan_results`, its indexes (`idx_ssr_type`, `idx_ssr_type_cat`), and the `scan_jobs` table.  
- Provide explicit error context on the schema-creation step to aid diagnostics (`Failed to ensure scanner schema invariants`).

### Testing
- Ran `cargo test --workspace`, which started compilation but failed due to a missing system dependency: the `glib-2.0` library required by `glib-sys` via `pkg-config`, so the test run could not complete.  
- The change is limited to DB initialization and was validated by inspecting the resulting code and SQL statements to ensure `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` are used for idempotent behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb24f1ac883278db860d8b3009750)