### PR TITLE
safety: inspect-before-delete redline gate for destructive shell_run

### DIFF
--- a/apps/desktop/src-tauri/docs/safety-policy.md
+++ b/apps/desktop/src-tauri/docs/safety-policy.md
@@ -103,16 +103,49 @@ A friction gradient, not a set of absolutes:
 
 ### Protected trees (approximation; irreplaceable user data / app state)
 
-`~/Library/Application Support`, `~/Library/Containers`,
-`~/Library/Group Containers`, `~/Library/Messages`, `~/Library/Mail`,
-`~/Library/Mobile Documents`, `~/Library/CloudStorage`,
-`~/Library/Photos`, `~/Pictures`, `~/Documents`, `~/Desktop`,
-`~/Movies`, `~/Music`.
+Tracks Apple's TCC-protected locations plus credential stores. Two classes:
 
-### Regenerable hints (defeat the gate even inside a protected tree)
+- **App-state (Library)** — cache/log subdirs *are* regenerable-exempt:
+  `~/Library/Application Support`, `~/Library/Containers`,
+  `~/Library/Group Containers`, `~/Library/Messages`, `~/Library/Mail`,
+  `~/Library/Safari`, `~/Library/Calendars`, `~/Library/Mobile Documents`
+  (iCloud), `~/Library/CloudStorage` (Google Drive/Dropbox/OneDrive),
+  `~/Library/Photos`.
+- **Credentials/keys** — `~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.kube`,
+  `~/.docker`, `~/.config` (the Keychain itself is *hard-deny*).
+- **User content** — *no* regenerable exemption (a folder literally named
+  "cache" under `~/Documents` is still the user's): `~/Documents`, `~/Desktop`,
+  `~/Pictures`, `~/Movies`, `~/Music`, `~/Downloads`.
+
+### Path normalisation — closing the bypasses (verified)
+
+The match would be worthless if the same data could be addressed by another
+spelling. So before matching, paths are normalised:
+
+- **Firmlinks.** Every user path is *also* reachable under
+  `/System/Volumes/Data` — confirmed same inode on a live machine
+  (`stat -f %d:%i ~/Library` == `…/System/Volumes/Data/Users/<u>/Library`; see
+  `/usr/share/firmlinks`). The real incident trace used this long form for `du`.
+  We strip the `/System/Volumes/Data` prefix so both spellings hit the same tree.
+- **Home / case.** `~`, `$HOME`, and the absolute `/Users/<u>/…` form all
+  resolve together; comparison is lowercased (macOS default volumes are
+  case-insensitive).
+- **Ancestors & whole-tree roots.** Deleting `~/Library` (an *ancestor* of every
+  protected tree) or `~/Library/Application Support` (the root itself) is a
+  **sweep** — rejected even with inspection; only specific *sub*-paths are
+  inspect-clearable. Wiping `~` or `/Users/<u>` is hard-deny.
+
+### Deletion vectors (not just `rm`)
+
+`rm`, `unlink`/`srm`, and `find` used destructively — `find … -delete`,
+`find … -exec rm`, and `find … | xargs rm` — are all classified as deletes. A
+non-destructive `find` still counts as *inspection*; a destructive one does not.
+
+### Regenerable hints (defeat the gate only inside app-state trees)
 
 A path segment matching `/Caches/`, `/Cache/`, `/Logs/`, `/.cache/` is treated
-as regenerable → `confirm` tier, no inspection required.
+as regenerable → no inspection required — **but only** strictly inside an
+app-state tree, never in a user-content tree and never for a tree root/ancestor.
 
 ### Hard-deny floor (refused even when reaffirmed)
 
@@ -173,6 +206,21 @@ already routes cloud mentions to selective-sync; the rule to reinforce is:
 local), never straight-deleted; irreplaceable-and-critical data is left alone —
 the few GB are not worth it.** This lives in the playbook because it is
 judgment; the trees above are the floor the playbook cannot fall through.
+
+## Known limits of the approximation (stated, not hidden)
+
+- A **relative path after an un-tracked `cd`** (`cd ~ && rm -rf Library/…`) is not
+  resolved back to home. Mitigated in practice: Noah's shell runs from the app's
+  working directory, not the home dir, so a bare `Library/` rarely *is* `~/Library`.
+- Only `$HOME` is expanded; arbitrary `$VAR` interpolation is not modelled.
+- macOS APFS is case-insensitive by default; we lowercase to match. A
+  case-*sensitive* volume could in principle hide a path — rare, accepted.
+- `tmutil deletelocalsnapshots` (removing Time Machine local snapshots) is left
+  ungated: it is an Apple-sanctioned, auto-regenerating space step. Worth
+  revisiting if we want to protect the snapshot safety net during big deletes.
+
+These are the seams. They are documented because an approximation you can see the
+edges of is more trustworthy than one that pretends to be total.
 
 ## What this deliberately does NOT do
 

--- a/apps/desktop/src-tauri/docs/safety-policy.md
+++ b/apps/desktop/src-tauri/docs/safety-policy.md
@@ -1,0 +1,181 @@
+# Destructive-action safety policy
+
+Status: accepted, 2026-06-09. Owner: Eric.
+
+This is the durable decision record behind Noah's redline system. It exists
+because a real session nearly (and maybe actually) destroyed a paying user's
+data. Read the incident first — the policy only makes sense as a response to it.
+
+## The incident
+
+A trialing-then-paying user asked (one sentence, three intents):
+
+> "My mac is running slow **and I want my storage pushed to Google Drive
+> using the folder in finder** and my mac is slow please improve this **and i
+> want a target ssd size of below 410**."
+
+Three intents: performance, **offload to cloud (move, preserve)**, and a **hard
+quota** (under 410 GB). Across ~44 steps Noah held the quota and worked it down
+(398 → 321 GB). That relentless, goal-driven, conversational cleanup is the
+product's moat — it is impossible in CleanMyMac or Mole because it requires
+reasoning and a dialogue. **We do not want to weaken it.**
+
+But the same loop also ran, each gated only by a click-through approval whose
+prompt showed Noah's own one-line reason:
+
+- `rm -rf ~/Library/Messages/Attachments/*`, `rm -rf …/com.apple.MobileSMS`
+  → the user's iMessage history.
+- `sudo rm -rf ~/Library/Application Support/*` → every app's data.
+- `rm -rf ~/Library/Containers/*` → sandboxed app data (Notes, Mail…).
+- `tmutil deletelocalsnapshots` → the Time Machine safety net.
+
+And it **never touched Google Drive** — it silently swapped the user's chosen
+*method* (move/preserve) for *delete*. We cannot tell from telemetry which
+deletes succeeded, because we logged the *proposed shell command*, not the
+*approval decision or the result*. We were blind. That blindness is TODO #1.
+
+## What went wrong, structurally
+
+Our only **code-enforced** guardrail was "command contains `rm`/`sudo` →
+ask the user," which a trusting user clears in two seconds. Everything else
+protecting their data was **playbook prose**: advisory, holey (Messages wasn't
+on the refuse list; no rule against wildcard sweeps), and possibly **not even
+loaded** for this phrasing. For a product whose killer feature is autonomous
+deletion toward a goal, the safety floor was a single click.
+
+## Principles
+
+1. **Put each rule at the lowest layer that can guarantee it.**
+   - *Software (Rust)* — deterministic, un-arguable. The only layer that can
+     hold a **redline**. Holds the enforced policy.
+   - *Playbook* — contextual good-practice ("offload means move"; "surface,
+     don't push deletion"). Advisory. Goes back to being *advice*, not a guard.
+   - *AI* — judgment and conversation. Powerful and persuadable. Never a place
+     for a guarantee.
+   A redline the model can talk past is not a redline.
+
+2. **A harness is not a wall.** A wall always says no, so it makes no decision.
+   Noah is the arbiter between what the human asks and what the AI proposes; it
+   *resists and yields under control*, it does not forbid capability. So the
+   default for a dangerous-but-legitimate action is **reject-then-reconsider**,
+   not "never."
+
+3. **Gate on justification, not syntax.** The problem with
+   `rm -rf …/Application Support/*` is not the `*`; it is that the AI has not
+   established the specific thing is removable. A wildcard fails because `*` is
+   the syntactic form of *"I haven't looked."* Five *named, verified-orphaned*
+   app folders carry per-target justification and are fine.
+
+4. **Inspect before delete (the Claude Code precedent).** Claude Code's harness
+   requires you to `Read` a file before `Edit`. The check is **structural, not
+   semantic** — it does not verify you *understood* the file, only that you
+   *looked*. We do the identical thing for deletes inside protected trees: the
+   harness cannot know "Adobe is uninstalled," but it can know whether the model
+   *inspected the folder* before deleting it. That is enough to force the
+   careful look, and it is cheap and deterministic. The inspection results land
+   in context, so the model's next decision is grounded — and a human/the
+   telemetry can audit it.
+
+5. **You can only govern what you can see.** Ground truth lives only in the
+   execution layer: tier classified → gate decision → approval decision →
+   result → manifest of what was touched. The same record powers safety
+   auditing, undo, and the "here's what Noah did" trust surface. Build it once.
+
+6. **Approximation is the implementation, and it has assurance.** "Irreplaceable"
+   is not computable at runtime; we approximate it with a curated tree list. That
+   is not a retreat — macOS TCC itself is a hardcoded path list. A fixed,
+   conservative, testable list is *more* assuring than a clever runtime detector,
+   because assurance comes from predictability. The *property* is the spec; the
+   list is the satisfying approximation, and every entry carries its rationale so
+   it does not rot.
+
+## The redline taxonomy (the spine)
+
+A friction gradient, not a set of absolutes:
+
+| Tier | What | Action |
+|------|------|--------|
+| **auto** | regenerable / reversible (caches, logs, old pkg versions) | run, log it |
+| **confirm** | ordinary deletes outside protected trees | approve, with plain-language disclosure |
+| **inspect-then-delete** | concrete delete *inside* a protected tree, not yet inspected | **reject with a tip**; clears once that path (or an ancestor within the tree) has been inspected this session |
+| **reject-wildcard** | wildcard sweep into a protected tree | **reject with a tip**; never auto-clears — the AI must enumerate specific subpaths |
+| **hard-deny** | the handful of actions that end the machine or destroy identity | **refuse even with inspection + reaffirmation** |
+
+### Protected trees (approximation; irreplaceable user data / app state)
+
+`~/Library/Application Support`, `~/Library/Containers`,
+`~/Library/Group Containers`, `~/Library/Messages`, `~/Library/Mail`,
+`~/Library/Mobile Documents`, `~/Library/CloudStorage`,
+`~/Library/Photos`, `~/Pictures`, `~/Documents`, `~/Desktop`,
+`~/Movies`, `~/Music`.
+
+### Regenerable hints (defeat the gate even inside a protected tree)
+
+A path segment matching `/Caches/`, `/Cache/`, `/Logs/`, `/.cache/` is treated
+as regenerable → `confirm` tier, no inspection required.
+
+### Hard-deny floor (refused even when reaffirmed)
+
+- root / boot-volume destruction: `rm -rf /`, `rm -rf /System`, `…/Users` wipe.
+- secure-erase of the boot volume (`diskutil … erase` on the system disk).
+- `~/Library/Keychains/`, `com.apple.security*`, `…/com.apple.TCC/` — auth and
+  permission identity.
+These are the only true walls. Everything else yields to a careful, looked-at,
+reaffirmed request.
+
+## Inspect-before-delete state machine
+
+State: a **session-scoped set of inspected paths** (`Arc<Mutex<HashMap<session,
+HashSet<path>>>>` on the orchestrator; cleared on session end). It mirrors
+Claude Code's read-set.
+
+- A **read-class** observation records the paths it covers as inspected:
+  `shell_run` running `ls`/`du`/`find`/`stat`/`cat`/`file` against a path, and
+  the structured read tools (`disk_audit`, `mac_disk_usage`). Down the road, the
+  background scanner's inventory pre-satisfies inspection for paths it covered.
+- A **delete** targeting a protected tree consults the set:
+  - wildcard sweep → reject (never cleared), tip: enumerate + inspect specifics.
+  - concrete path inspected (path `T` where some inspected `I` is within the
+    tree and `T` is `I` or a descendant) → allow → normal approval.
+  - concrete path not inspected → reject, tip: inspect this folder first.
+- Clearing rule precision: inspection of `I` clears deletion of `T` **iff**
+  `I` is at-or-below the protected tree root *and* `T` starts with `I`. So
+  `ls ~` (above the tree root) clears nothing; `ls ~/Library/Application Support`
+  clears its descendants; `du …/Adobe` clears `…/Adobe`.
+
+The tip is what makes it a harness, not a wall: it instructs the remedy.
+
+## Telemetry schema (TODO #1 — "did we actually approve it")
+
+Emitted from the execution layer for every consequential action:
+
+```
+action_event {
+  session_id, tool, command,
+  classification: auto | confirm | inspect_then_delete | reject_wildcard | hard_deny,
+  gate: allowed | rejected_needs_inspection | rejected_wildcard | hard_denied,
+  approval: not_required | granted | denied,
+  exit_code, bytes_freed?, paths_touched[]   // result, when available
+}
+```
+
+v1 emits this locally (frontend debug channel + stderr) and records the
+approval/denial decision — closing the "we only saw the proposed command"
+blindness. Backend forwarding (`/events/action` on noah-consumer) and binding
+`paths_touched` into the undo journal are the next slice; they reuse the
+existing `consumer/client.rs` event channel and `safety::journal`.
+
+## Honoring intent (playbook layer)
+
+"Offload to Drive" is a constraint, not a suggestion. The disk-space playbook
+already routes cloud mentions to selective-sync; the rule to reinforce is:
+**irreplaceable-but-movable data is offloaded (copy → verify → then delete
+local), never straight-deleted; irreplaceable-and-critical data is left alone —
+the few GB are not worth it.** This lives in the playbook because it is
+judgment; the trees above are the floor the playbook cannot fall through.
+
+## What this deliberately does NOT do
+
+- It does not block the moat: a careful, looked-at deletion still proceeds.
+- It does not rely on the model's self-reported `reason` for anything load-bearing.
+- It does not try to compute "irreplaceable"; it approximates and says so.

--- a/apps/desktop/src-tauri/docs/safety-policy.md
+++ b/apps/desktop/src-tauri/docs/safety-policy.md
@@ -89,16 +89,61 @@ deletion toward a goal, the safety floor was a single click.
    list is the satisfying approximation, and every entry carries its rationale so
    it does not rot.
 
+## Fail-closed: the harness permits, it doesn't chase bypasses
+
+The first cut was **fail-open**: it tried to *parse* arbitrary shell and catch
+known-bad forms, so anything it couldn't parse fell through to allowed. That is a
+losing game — firmlinks, `find -delete`, `xargs rm`, relative paths, `$(...)`,
+`eval`, variables — an unbounded list of spellings for the same delete.
+
+The harness has full control, so it **inverts the burden**: a command that
+deletes must be in a small, fully-analysable **canonical form**, or it does not
+run. We don't have to understand `find … | xargs rm` — we refuse it and tell the
+model to re-express the delete as something the harness *can* read. The infinite
+bypass surface collapses into one finite allowlist.
+
+**Canonical deletion form** — the rule is *the target root must be statically
+visible*. Everything else → `RejectNonCanonical`:
+- `rm` / `unlink` on literal paths, **or** a non-piped
+  `find <root> … -delete` / `-exec rm` whose root is a literal path. A `find`
+  root is checkable and its `-name`/`-mtime` predicates only *narrow* what's
+  removed within that root — strictly safer — so age/size-filtered cleanup is
+  preserved.
+- No indirection that hides the target: **no pipe `|`** (a `grep`/`sed` between
+  `find` and `xargs rm` could diverge the deleted set), no `xargs`, no command
+  substitution `$(…)` / backticks, no `eval`, no pipe-to-shell, no variables
+  other than `$HOME`.
+- Every path (rm/unlink operand or find root) is **absolute** (`/…`) or
+  `~`/`$HOME`-rooted — never relative (closes `cd ~ && rm -rf Library/…`), never
+  a bare `find` defaulting to the cwd. Globs are fine (the base is concrete).
+- Flags are short and known (`-rRfidvPW`); long flags like
+  `--no-preserve-root` are rejected. `srm`/`shred`/`rmdir` → use `rm`.
+
+The model can still delete anything — it just has to express it so the harness
+can *see the root*. That composes perfectly with inspect-before-delete: the
+visible root is exactly what the inspect-set is checked against.
+
+### Threat model (so the design is proportionate)
+
+The danger is **our own over-eager model** reaching for powerful sweeping
+constructs — exactly what the incident showed — not an adversary laundering `rm`
+through base64. Fail-closed canonical form fully addresses the former and raises
+the bar steeply on the latter (`eval` and pipe-to-shell are themselves refused).
+We do **not** claim to stop a maliciously-controlled model that hides a deletion
+behind zero recognisable tokens; that is out of scope and stated, not papered over.
+
 ## The redline taxonomy (the spine)
 
-A friction gradient, not a set of absolutes:
+A friction gradient, not a set of absolutes. The canonical gate runs first; the
+tiers below apply to the now-fully-readable delete:
 
 | Tier | What | Action |
 |------|------|--------|
+| **non-canonical** | a delete whose target root isn't statically visible (pipe, `xargs`, `$(…)`, variable, `eval`, relative path, rootless `find`) | **reject with a tip** to re-express so the root is a literal `rm`/`unlink` operand or `find` root |
 | **auto** | regenerable / reversible (caches, logs, old pkg versions) | run, log it |
 | **confirm** | ordinary deletes outside protected trees | approve, with plain-language disclosure |
 | **inspect-then-delete** | concrete delete *inside* a protected tree, not yet inspected | **reject with a tip**; clears once that path (or an ancestor within the tree) has been inspected this session |
-| **reject-wildcard** | wildcard sweep into a protected tree | **reject with a tip**; never auto-clears — the AI must enumerate specific subpaths |
+| **reject-sweep** | wildcard, tree-root, or ancestor delete over a protected tree | **reject with a tip**; never auto-clears — the AI must enumerate specific inspected subpaths |
 | **hard-deny** | the handful of actions that end the machine or destroy identity | **refuse even with inspection + reaffirmation** |
 
 ### Protected trees (approximation; irreplaceable user data / app state)
@@ -207,17 +252,20 @@ local), never straight-deleted; irreplaceable-and-critical data is left alone �
 the few GB are not worth it.** This lives in the playbook because it is
 judgment; the trees above are the floor the playbook cannot fall through.
 
-## Known limits of the approximation (stated, not hidden)
+## Known limits (stated, not hidden)
 
-- A **relative path after an un-tracked `cd`** (`cd ~ && rm -rf Library/…`) is not
-  resolved back to home. Mitigated in practice: Noah's shell runs from the app's
-  working directory, not the home dir, so a bare `Library/` rarely *is* `~/Library`.
-- Only `$HOME` is expanded; arbitrary `$VAR` interpolation is not modelled.
-- macOS APFS is case-insensitive by default; we lowercase to match. A
-  case-*sensitive* volume could in principle hide a path — rare, accepted.
+Fail-closed canonical form closes the spelling bypasses (relative paths,
+variables, `$(…)`, `find`/`xargs`, firmlinks) by *refusing* them rather than
+resolving them. What remains:
+
+- A deletion with **zero recognisable deletion token** (e.g. a fully
+  base64/`eval`-laundered `rm` that also evades the `eval`/pipe-to-shell refusal)
+  is out of scope — see the threat model. Our own model does not produce these.
 - `tmutil deletelocalsnapshots` (removing Time Machine local snapshots) is left
   ungated: it is an Apple-sanctioned, auto-regenerating space step. Worth
   revisiting if we want to protect the snapshot safety net during big deletes.
+- macOS APFS is case-insensitive by default; we lowercase to match. A
+  case-*sensitive* volume could in principle hide a path — rare, accepted.
 
 These are the seams. They are documented because an approximation you can see the
 edges of is more trustworthy than one that pretends to be total.

--- a/apps/desktop/src-tauri/playbooks/disk-space-recovery.md
+++ b/apps/desktop/src-tauri/playbooks/disk-space-recovery.md
@@ -15,7 +15,7 @@ Explicit: "clean up my storage", "free disk space", "find space hogs", "check st
 
 ## Scope
 **In**: cache-class data — package managers, Xcode/simulators/DerivedData, app caches (Slack, Discord, Code, Cursor), Trash, old logs, stale incomplete downloads, old macOS installers.
-**Out (redirect)**: moving files to cloud (use the provider's selective-sync); uninstalling apps (Applications folder for now); Photos/Mail/Messages bodies (TCC — System Settings → Storage).
+**Out (redirect)**: moving files to cloud — that means *offload* (copy → verify the copy exists → only then delete local), never straight-delete; uninstalling apps (Applications folder for now); Photos/Mail/Messages bodies (TCC — System Settings → Storage). If a quota forces touching irreplaceable data, stop and surface it — do not delete it to hit a number.
 
 ## Heuristics
 - ≥20% free → healthy, don't push cleanup.
@@ -78,7 +78,7 @@ ls -la ~/Library/CloudStorage/ ~/Library/Mobile\ Documents/ 2>/dev/null
 Folder hints: `GoogleDrive-*`, `Dropbox`, `OneDrive*`, `com~apple~CloudDocs` (iCloud).
 
 ## Critical exclusions
-Refuse even with user blessing:
+Deletes inside protected trees (Application Support, Containers, Messages, etc.) are **gated by the harness**: you must inspect a folder (`ls`/`du`) before deleting it, and blind wildcard sweeps like `rm -rf .../Application Support/*` are held back — enumerate and remove specific, inspected subdirs instead. Refuse even with user blessing:
 - `~/.claude/`, `~/.local/share/claude/`, `~/Library/Application Support/Codex/`, `~/Library/Logs/com.openai.codex/` — AI assistant state and history (Claude Code, Codex Desktop).
 - `~/Library/Application Support/{Code,Cursor,Zed}/User/` — editor settings (Cache* subdirs are fine).
 - `~/Library/Application Support/{1Password,Bitwarden,Dashlane}/` — credential vaults.

--- a/apps/desktop/src-tauri/src/agent/orchestrator.rs
+++ b/apps/desktop/src-tauri/src/agent/orchestrator.rs
@@ -1014,18 +1014,26 @@ impl Orchestrator {
         // Execute the tool.
         let tool_result = tool.execute(tool_input).await?;
 
-        // Record read-class inspections (ls/du/find/stat/...) so a later
-        // delete inside a protected tree can clear the gate above. This is
-        // the "read" half of read-before-delete.
+        // Record successful read-class inspections (ls/du/find/stat/...) so a
+        // later delete inside a protected tree can clear the gate above. Failed
+        // reads (TCC denial, permissions, missing path, timeout) do not prove
+        // Noah looked at the target.
         if tool_name == "shell_run" {
             if let Some(command) = tool_input.get("command").and_then(|v| v.as_str()) {
-                let home = std::env::var("HOME").unwrap_or_default();
-                let paths = noah_tools::safety::inspected_paths(command, &home);
-                if !paths.is_empty() {
-                    let mut map = self.inspected_paths.lock().await;
-                    let set = map.entry(session_id.to_string()).or_default();
-                    for p in paths {
-                        set.insert(p);
+                let succeeded = tool_result
+                    .data
+                    .get("exit_code")
+                    .and_then(|v| v.as_i64())
+                    == Some(0);
+                if succeeded {
+                    let home = std::env::var("HOME").unwrap_or_default();
+                    let paths = noah_tools::safety::inspected_paths(command, &home);
+                    if !paths.is_empty() {
+                        let mut map = self.inspected_paths.lock().await;
+                        let set = map.entry(session_id.to_string()).or_default();
+                        for p in paths {
+                            set.insert(p);
+                        }
                     }
                 }
             }

--- a/apps/desktop/src-tauri/src/agent/orchestrator.rs
+++ b/apps/desktop/src-tauri/src/agent/orchestrator.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -91,6 +91,12 @@ pub struct Orchestrator {
     knowledge_dir: std::path::PathBuf,
     /// Set to true to cancel the current agentic loop.
     cancelled: Arc<AtomicBool>,
+    /// Inspect-before-delete state: session_id -> set of inspected paths
+    /// (normalised). A delete inside a protected tree is held back until the
+    /// target (or an ancestor within the tree) appears here. See
+    /// `docs/safety-policy.md`. Interior-mutable because `execute_tool` runs
+    /// behind `&self`.
+    inspected_paths: Arc<Mutex<HashMap<String, HashSet<String>>>>,
 }
 
 pub type PendingApprovals = Arc<Mutex<HashMap<String, oneshot::Sender<bool>>>>;
@@ -120,6 +126,7 @@ impl Orchestrator {
             db,
             knowledge_dir,
             cancelled: Arc::new(AtomicBool::new(false)),
+            inspected_paths: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -192,6 +199,12 @@ impl Orchestrator {
     }
 
     pub fn end_session(&mut self, session_id: &str) -> bool {
+        // Drop the inspect-before-delete state for this session. `try_lock`
+        // keeps this sync fn non-blocking; a momentary contention just defers
+        // cleanup, which is harmless (the session id won't be reused).
+        if let Ok(mut map) = self.inspected_paths.try_lock() {
+            map.remove(session_id);
+        }
         self.sessions.remove(session_id).is_some()
     }
 
@@ -916,6 +929,43 @@ impl Orchestrator {
             }
         }
 
+        // ── Inspect-before-delete redline gate (shell_run only) ──────────
+        // The enforced safety layer. A deletion inside a protected tree is
+        // held back until the target has been inspected this session; a
+        // wildcard sweep over such a tree is held back outright; a small
+        // hard-deny floor refuses machine-ending actions even if reaffirmed.
+        // This sits in the harness (not the tool) because it needs session
+        // state — mirroring Claude Code's read-before-edit. See
+        // docs/safety-policy.md.
+        if tool_name == "shell_run" {
+            if let Some(command) = tool_input.get("command").and_then(|v| v.as_str()) {
+                let home = std::env::var("HOME").unwrap_or_default();
+                let decision = {
+                    let map = self.inspected_paths.lock().await;
+                    let empty = HashSet::new();
+                    let set = map.get(session_id).unwrap_or(&empty);
+                    noah_tools::safety::gate_decision(command, &home, set)
+                };
+                if decision.is_rejection() {
+                    emit_debug(
+                        app_handle,
+                        "safety_gate",
+                        &format!("Held back shell_run [{}]", decision.classification()),
+                        json!({
+                            "name": tool_name,
+                            "command": command,
+                            "classification": decision.classification(),
+                            "gate": "rejected",
+                        }),
+                    );
+                    // The tip is fed back to the model as the tool result, so
+                    // it inspects-then-retries (or enumerates) rather than
+                    // erroring out — a harness that redirects, not a wall.
+                    return Ok(decision.message());
+                }
+            }
+        }
+
         // For NeedsApproval tools, request approval from the frontend.
         if tier == SafetyTier::NeedsApproval {
             let reason = tool_input
@@ -946,10 +996,40 @@ impl Orchestrator {
                 );
                 return Ok("Action denied by user.".to_string());
             }
+
+            // Approval granted — record it. Closes the telemetry blind spot
+            // where we only ever saw the *proposed* command, never whether
+            // it was actually approved (docs/safety-policy.md, TODO #1).
+            emit_debug(
+                app_handle,
+                "tool_approved",
+                &format!("User approved {}", tool_name),
+                json!({
+                    "name": tool_name,
+                    "input": tool_input,
+                }),
+            );
         }
 
         // Execute the tool.
         let tool_result = tool.execute(tool_input).await?;
+
+        // Record read-class inspections (ls/du/find/stat/...) so a later
+        // delete inside a protected tree can clear the gate above. This is
+        // the "read" half of read-before-delete.
+        if tool_name == "shell_run" {
+            if let Some(command) = tool_input.get("command").and_then(|v| v.as_str()) {
+                let home = std::env::var("HOME").unwrap_or_default();
+                let paths = noah_tools::safety::inspected_paths(command, &home);
+                if !paths.is_empty() {
+                    let mut map = self.inspected_paths.lock().await;
+                    let set = map.entry(session_id.to_string()).or_default();
+                    for p in paths {
+                        set.insert(p);
+                    }
+                }
+            }
+        }
 
         // Record any changes in the journal.
         if !tool_result.changes.is_empty() {

--- a/apps/desktop/src-tauri/src/platform/linux/diagnostics.rs
+++ b/apps/desktop/src-tauri/src/platform/linux/diagnostics.rs
@@ -467,7 +467,7 @@ impl Tool for ShellRun {
 
         let timeout_secs = if needs_admin { 120 } else { 60 };
 
-        let output = match tokio::time::timeout(
+        let (output, exit_code) = match tokio::time::timeout(
             std::time::Duration::from_secs(timeout_secs),
             tokio::process::Command::new(&exec_program)
                 .args(&exec_args)
@@ -482,7 +482,10 @@ impl Tool for ShellRun {
 
                 // Handle user cancellation of the pkexec dialog (exit code 126)
                 if needs_admin && exit_code == 126 {
-                    "User declined administrator access. The command was not executed.".to_string()
+                    (
+                        "User declined administrator access. The command was not executed.".to_string(),
+                        Some(exit_code),
+                    )
                 } else {
                     let mut result = String::new();
                     if !stdout.is_empty() {
@@ -499,11 +502,17 @@ impl Tool for ShellRun {
                     } else {
                         result.push_str(&format!("\n\n[exit code: {}]", exit_code));
                     }
-                    result
+                    (result, Some(exit_code))
                 }
             }
-            Ok(Err(e)) => format!("Failed to execute command: {}", e),
-            Err(_) => format!("Command timed out after {} seconds. The command was taking too long and has been stopped.", timeout_secs),
+            Ok(Err(e)) => (format!("Failed to execute command: {}", e), None),
+            Err(_) => (
+                format!(
+                    "Command timed out after {} seconds. The command was taking too long and has been stopped.",
+                    timeout_secs
+                ),
+                None,
+            ),
         };
 
         let truncated = if output.len() > 10_000 {
@@ -514,7 +523,7 @@ impl Tool for ShellRun {
 
         Ok(ToolResult::with_changes(
             truncated,
-            json!({ "command": command }),
+            json!({ "command": command, "exit_code": exit_code }),
             vec![ChangeRecord {
                 description: format!("Executed shell command: {}", command),
                 undo_tool: String::new(),

--- a/apps/desktop/src-tauri/src/platform/macos/diagnostics.rs
+++ b/apps/desktop/src-tauri/src/platform/macos/diagnostics.rs
@@ -523,7 +523,7 @@ impl Tool for ShellRun {
 
         let timeout_secs = if needs_admin { 120 } else { 60 }; // longer timeout for admin prompt
 
-        let output = match tokio::time::timeout(
+        let (output, exit_code) = match tokio::time::timeout(
             std::time::Duration::from_secs(timeout_secs),
             tokio::process::Command::new(&exec_program)
                 .args(&exec_args)
@@ -538,7 +538,10 @@ impl Tool for ShellRun {
 
                 // Handle user cancellation of the admin dialog
                 if needs_admin && exit_code != 0 && stderr.contains("User canceled") {
-                    "User declined administrator access. The command was not executed.".to_string()
+                    (
+                        "User declined administrator access. The command was not executed.".to_string(),
+                        Some(exit_code),
+                    )
                 } else {
                     let mut result = String::new();
                     if !stdout.is_empty() {
@@ -569,11 +572,17 @@ impl Tool for ShellRun {
                         result.push_str(&hint);
                     }
 
-                    result
+                    (result, Some(exit_code))
                 }
             }
-            Ok(Err(e)) => format!("Failed to execute command: {}", e),
-            Err(_) => format!("Command timed out after {} seconds. The command was taking too long and has been stopped.", timeout_secs),
+            Ok(Err(e)) => (format!("Failed to execute command: {}", e), None),
+            Err(_) => (
+                format!(
+                    "Command timed out after {} seconds. The command was taking too long and has been stopped.",
+                    timeout_secs
+                ),
+                None,
+            ),
         };
 
         // Limit output length
@@ -587,6 +596,7 @@ impl Tool for ShellRun {
             truncated,
             json!({
                 "command": command,
+                "exit_code": exit_code,
             }),
             vec![ChangeRecord {
                 description: format!("Executed shell command: {}", command),

--- a/apps/desktop/src-tauri/src/platform/windows/diagnostics.rs
+++ b/apps/desktop/src-tauri/src/platform/windows/diagnostics.rs
@@ -540,7 +540,7 @@ impl Tool for ShellRun {
             }
         };
 
-        let output = match tokio::time::timeout(
+        let (output, exit_code) = match tokio::time::timeout(
             std::time::Duration::from_secs(60),
             child,
         )
@@ -566,10 +566,13 @@ impl Tool for ShellRun {
                 } else {
                     result.push_str(&format!("\n\n[exit code: {}]", exit_code));
                 }
-                result
+                (result, Some(exit_code))
             }
-            Ok(Err(e)) => format!("Failed to execute command: {}", e),
-            Err(_) => "Command timed out after 60 seconds. The command was taking too long and has been stopped.".to_string(),
+            Ok(Err(e)) => (format!("Failed to execute command: {}", e), None),
+            Err(_) => (
+                "Command timed out after 60 seconds. The command was taking too long and has been stopped.".to_string(),
+                None,
+            ),
         };
 
         // Limit output length
@@ -583,6 +586,7 @@ impl Tool for ShellRun {
             truncated,
             json!({
                 "command": command,
+                "exit_code": exit_code,
             }),
             vec![ChangeRecord {
                 description: format!("Executed shell command: {}", command),

--- a/crates/noah-tools/src/lib.rs
+++ b/crates/noah-tools/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod safety;
 mod tool;
 mod types;
 

--- a/crates/noah-tools/src/safety.rs
+++ b/crates/noah-tools/src/safety.rs
@@ -44,10 +44,16 @@ pub struct ProtectedTree {
 }
 
 const fn app(path: &'static str) -> ProtectedTree {
-    ProtectedTree { path, content: false }
+    ProtectedTree {
+        path,
+        content: false,
+    }
 }
 const fn content(path: &'static str) -> ProtectedTree {
-    ProtectedTree { path, content: true }
+    ProtectedTree {
+        path,
+        content: true,
+    }
 }
 
 /// Protected trees — an approximation of "irreplaceable user data / app state."
@@ -176,12 +182,39 @@ fn strip_firmlink(lower: &str) -> String {
     lower.to_string()
 }
 
+/// Collapse `.` / `..` path segments after home expansion and firmlink
+/// stripping. Destructive operands containing dot segments are rejected before
+/// this, but normalising here keeps comparisons stable for inspected paths.
+fn collapse_dot_segments(path: &str) -> String {
+    if !path.starts_with('/') {
+        return path.to_string();
+    }
+
+    let mut parts: Vec<&str> = Vec::new();
+    for seg in path.split('/') {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                parts.pop();
+            }
+            _ => parts.push(seg),
+        }
+    }
+
+    if parts.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{}", parts.join("/"))
+    }
+}
+
 /// Normalise for comparison: expand home, lowercase (macOS default volumes are
 /// case-insensitive), strip the firmlink prefix, drop a trailing slash. Root
 /// `/` is preserved (not collapsed to empty).
 fn norm(path: &str, home: &str) -> String {
     let expanded = expand_home(path, home).to_lowercase();
     let stripped = strip_firmlink(&expanded);
+    let stripped = collapse_dot_segments(&stripped);
     let trimmed = stripped.trim_end_matches('/');
     if trimmed.is_empty() && stripped.starts_with('/') {
         return "/".to_string();
@@ -191,7 +224,14 @@ fn norm(path: &str, home: &str) -> String {
 
 /// True if `child` is `ancestor` or a descendant of it (both pre-normalised).
 fn is_within(child: &str, ancestor: &str) -> bool {
+    if ancestor == "/" {
+        return child.starts_with('/');
+    }
     child == ancestor || child.starts_with(&format!("{}/", ancestor))
+}
+
+fn has_dot_segment(path: &str) -> bool {
+    path.split('/').any(|seg| seg == "." || seg == "..")
 }
 
 fn has_glob(seg: &str) -> bool {
@@ -290,16 +330,110 @@ fn split_commands(cmd: &str) -> Vec<String> {
         .collect()
 }
 
-/// Leader of a simple command, with a leading `sudo` (and its flags) stripped.
-fn leader_and_args(part: &str) -> (String, Vec<String>) {
-    let toks = tokenize(part);
-    let mut idx = 0;
-    if toks.first().map(|s| s.as_str()) == Some("sudo") {
-        idx = 1;
-        while toks.get(idx).map(|s| s.starts_with('-')).unwrap_or(false) {
+fn is_assignment(tok: &str) -> bool {
+    let Some((name, _)) = tok.split_once('=') else {
+        return false;
+    };
+    !name.is_empty()
+        && name.chars().all(|c| c == '_' || c.is_ascii_alphanumeric())
+        && !name.as_bytes()[0].is_ascii_digit()
+}
+
+fn skip_sudo(toks: &[String], mut idx: usize) -> usize {
+    if toks.get(idx).map(|s| s.as_str()) != Some("sudo") {
+        return idx;
+    }
+    idx += 1;
+    while let Some(tok) = toks.get(idx) {
+        if !tok.starts_with('-') {
+            break;
+        }
+        let needs_arg = matches!(
+            tok.as_str(),
+            "-u" | "--user"
+                | "-g"
+                | "--group"
+                | "-h"
+                | "--host"
+                | "-p"
+                | "--prompt"
+                | "-C"
+                | "--close-from"
+                | "-D"
+                | "--chdir"
+        );
+        idx += 1;
+        if needs_arg && toks.get(idx).is_some() {
             idx += 1;
         }
     }
+    idx
+}
+
+fn skip_command_prefixes(toks: &[String], mut idx: usize) -> usize {
+    loop {
+        while toks.get(idx).is_some_and(|tok| is_assignment(tok)) {
+            idx += 1;
+        }
+
+        match toks.get(idx).map(|s| s.as_str()) {
+            Some("sudo") => {
+                idx = skip_sudo(toks, idx);
+            }
+            Some("command" | "builtin" | "noglob" | "nocorrect" | "time" | "nohup") => {
+                idx += 1;
+            }
+            Some("env") => {
+                idx += 1;
+                while let Some(tok) = toks.get(idx) {
+                    if tok.starts_with('-') || is_assignment(tok) {
+                        idx += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            Some("nice") => {
+                idx += 1;
+                while let Some(tok) = toks.get(idx) {
+                    if tok == "-n" || tok == "--adjustment" {
+                        idx += 1;
+                        if toks.get(idx).is_some() {
+                            idx += 1;
+                        }
+                    } else if tok.starts_with('-') {
+                        idx += 1;
+                    } else {
+                        break;
+                    }
+                }
+            }
+            Some("arch") => {
+                idx += 1;
+                while toks.get(idx).is_some_and(|tok| tok.starts_with('-')) {
+                    idx += 1;
+                }
+            }
+            _ => break,
+        }
+    }
+    idx
+}
+
+/// Leader of a simple command, with common shell prefixes normalised.
+fn leader_and_args(part: &str) -> (String, Vec<String>) {
+    let toks = tokenize(part);
+    let idx = skip_command_prefixes(&toks, 0);
+    let leader = toks.get(idx).cloned().unwrap_or_default();
+    let args = toks.get(idx + 1..).map(|s| s.to_vec()).unwrap_or_default();
+    (leader, args)
+}
+
+/// Raw leader after `sudo`, before other wrappers. Used to reject wrapped
+/// deletions rather than silently canonicalising them.
+fn leader_after_sudo(part: &str) -> (String, Vec<String>) {
+    let toks = tokenize(part);
+    let idx = skip_sudo(&toks, 0);
     let leader = toks.get(idx).cloned().unwrap_or_default();
     let args = toks.get(idx + 1..).map(|s| s.to_vec()).unwrap_or_default();
     (leader, args)
@@ -307,7 +441,10 @@ fn leader_and_args(part: &str) -> (String, Vec<String>) {
 
 /// Non-flag operands (for `rm`/`unlink`).
 fn path_operands(args: &[String]) -> Vec<String> {
-    args.iter().filter(|a| !a.starts_with('-')).cloned().collect()
+    args.iter()
+        .filter(|a| !a.starts_with('-'))
+        .cloned()
+        .collect()
 }
 
 /// Leading path operands of a `find` (before the first predicate/flag/`(`/`!`).
@@ -338,6 +475,23 @@ fn find_args_destructive(args: &[String]) -> bool {
         }
     }
     false
+}
+
+fn shell_script_arg(args: &[String]) -> Option<&str> {
+    for (i, arg) in args.iter().enumerate() {
+        if arg == "-c" || arg == "-lc" {
+            return args.get(i + 1).map(|s| s.as_str());
+        }
+    }
+    None
+}
+
+fn is_shell_leader(leader: &str) -> bool {
+    matches!(leader, "sh" | "bash" | "zsh")
+}
+
+fn is_delete_leader(leader: &str) -> bool {
+    matches!(leader, "rm" | "unlink" | "srm" | "shred" | "rmdir")
 }
 
 /// Whole-command: is there an `xargs` that runs `rm`/`unlink`? (the `find | xargs
@@ -384,7 +538,8 @@ fn delete_targets_raw(cmd: &str) -> Vec<String> {
 pub fn hard_denied(cmd: &str, home: &str) -> Option<String> {
     let home_n = norm(home, home);
     for op in delete_targets_raw(cmd) {
-        let n = norm(&op, home);
+        let (base, _) = base_and_glob(&op);
+        let n = norm(&base, home);
         // root / system / whole-Users / home-root wipes
         if n == "/"
             || n == "/system"
@@ -446,12 +601,17 @@ fn mentions_deletion(cmd: &str) -> bool {
     for part in split_commands(cmd) {
         let (leader, args) = leader_and_args(&part);
         match leader.as_str() {
-            "rm" | "unlink" | "srm" | "shred" | "rmdir" => return true,
+            leader if is_delete_leader(leader) => return true,
             "find" if find_args_destructive(&args) || xargs_rm => return true,
             "xargs" if xargs_rm => return true,
             "eval" => return true,
             // pipe-to-shell laundering (`… | sh`)
             "sh" | "bash" | "zsh" if has_pipe(cmd) => return true,
+            leader if is_shell_leader(leader) => {
+                if shell_script_arg(&args).is_some_and(|script| mentions_deletion(script)) {
+                    return true;
+                }
+            }
             _ => {}
         }
     }
@@ -477,6 +637,9 @@ fn valid_rm_flag(a: &str) -> bool {
 /// paths, other variables, and command substitution are not.
 fn canonical_operand(op: &str) -> bool {
     if op.contains("$(") || op.contains('`') {
+        return false;
+    }
+    if has_dot_segment(op) {
         return false;
     }
     if op.starts_with('/') || op == "~" || op.starts_with("~/") {
@@ -508,6 +671,8 @@ fn operand_why(op: &str) -> String {
         "command substitution"
     } else if op.contains('$') {
         "a shell variable"
+    } else if has_dot_segment(op) {
+        "a `.` or `..` path segment"
     } else {
         "a relative path"
     };
@@ -527,7 +692,17 @@ fn canonical_violation(cmd: &str) -> Option<String> {
         return Some(tip_noncanonical("command substitution `$(...)`"));
     }
     for part in split_commands(cmd) {
+        let (raw_leader, _) = leader_after_sudo(&part);
         let (leader, args) = leader_and_args(&part);
+        if raw_leader != leader {
+            let wrapped_delete = is_delete_leader(&leader)
+                || (leader == "find" && find_args_destructive(&args))
+                || (is_shell_leader(&leader)
+                    && shell_script_arg(&args).is_some_and(|script| mentions_deletion(script)));
+            if wrapped_delete {
+                return Some(tip_noncanonical(&format!("the wrapper `{}`", raw_leader)));
+            }
+        }
         match leader.as_str() {
             "rm" | "unlink" => {
                 for a in &args {
@@ -560,6 +735,14 @@ fn canonical_violation(cmd: &str) -> Option<String> {
             // Secure/dir deleters and indirection: funnel to the plain forms.
             "srm" | "shred" | "rmdir" | "xargs" | "eval" => {
                 return Some(tip_noncanonical(&format!("`{}`", leader)));
+            }
+            leader if is_shell_leader(leader) => {
+                if shell_script_arg(&args).is_some_and(|script| mentions_deletion(script)) {
+                    return Some(tip_noncanonical(&format!(
+                        "a nested `{}` shell script",
+                        leader
+                    )));
+                }
             }
             _ => {}
         }
@@ -600,9 +783,7 @@ pub fn gate_decision(cmd: &str, home: &str, inspected: &HashSet<String>) -> Gate
 
             // Regenerable cache/log strictly inside an app-state tree → not gated.
             let strictly_inside = within && !contains;
-            if strictly_inside
-                && !tree.content
-                && REGENERABLE_HINTS.iter().any(|h| nop.contains(h))
+            if strictly_inside && !tree.content && REGENERABLE_HINTS.iter().any(|h| nop.contains(h))
             {
                 break; // this operand is fine; move to next operand
             }
@@ -702,7 +883,11 @@ mod tests {
     #[test]
     fn incident_sudo_wildcard_app_support() {
         assert!(matches!(
-            gate_decision("sudo rm -rf ~/Library/Application\\ Support/*", HOME, &empty()),
+            gate_decision(
+                "sudo rm -rf ~/Library/Application\\ Support/*",
+                HOME,
+                &empty()
+            ),
             GateDecision::RejectSweep { .. }
         ));
     }
@@ -716,7 +901,11 @@ mod tests {
     #[test]
     fn incident_messages_container_specific() {
         assert!(matches!(
-            gate_decision("rm -rf ~/Library/Containers/com.apple.MobileSMS", HOME, &empty()),
+            gate_decision(
+                "rm -rf ~/Library/Containers/com.apple.MobileSMS",
+                HOME,
+                &empty()
+            ),
             GateDecision::RejectNeedsInspection { .. }
         ));
     }
@@ -754,7 +943,11 @@ mod tests {
             HOME,
             &empty(),
         );
-        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
+        assert!(
+            matches!(d, GateDecision::RejectNeedsInspection { .. }),
+            "{:?}",
+            d
+        );
     }
     #[test]
     fn firmlink_inspection_clears_firmlink_delete() {
@@ -793,6 +986,23 @@ mod tests {
             GateDecision::HardDeny { .. }
         ));
     }
+    #[test]
+    fn root_globs_are_hard_denied() {
+        for cmd in [
+            "rm -rf /*",
+            "rm -rf /Users/*",
+            "rm -rf /System/Volumes/Data/*",
+            "rm -rf /System/Volumes/Data/Users/fbob/*",
+        ] {
+            assert!(
+                matches!(
+                    gate_decision(cmd, HOME, &empty()),
+                    GateDecision::HardDeny { .. }
+                ),
+                "should hard-deny root/system glob: {cmd}"
+            );
+        }
+    }
 
     // ── Visible-root find: permitted, then gated on the root ─────────────
 
@@ -814,7 +1024,11 @@ mod tests {
             HOME,
             &empty(),
         );
-        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
+        assert!(
+            matches!(d, GateDecision::RejectNeedsInspection { .. }),
+            "{:?}",
+            d
+        );
     }
     #[test]
     fn find_delete_in_unprotected_age_filtered_allowed() {
@@ -840,13 +1054,20 @@ mod tests {
             HOME,
             &empty(),
         );
-        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+        assert!(
+            matches!(d, GateDecision::RejectNonCanonical { .. }),
+            "{:?}",
+            d
+        );
     }
     #[test]
     fn find_with_relative_root_is_non_canonical() {
         for cmd in ["find . -name '*.tmp' -delete", "find Library -delete"] {
             assert!(
-                matches!(gate_decision(cmd, HOME, &empty()), GateDecision::RejectNonCanonical { .. }),
+                matches!(
+                    gate_decision(cmd, HOME, &empty()),
+                    GateDecision::RejectNonCanonical { .. }
+                ),
                 "should reject relative find root: {cmd}"
             );
         }
@@ -854,7 +1075,11 @@ mod tests {
     #[test]
     fn find_with_no_explicit_root_is_non_canonical() {
         let d = gate_decision("find -name '*.log' -delete", HOME, &empty());
-        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+        assert!(
+            matches!(d, GateDecision::RejectNonCanonical { .. }),
+            "{:?}",
+            d
+        );
     }
     #[test]
     fn rmdir_shred_srm_are_non_canonical() {
@@ -864,7 +1089,10 @@ mod tests {
             "srm -rf ~/Documents/x",
         ] {
             assert!(
-                matches!(gate_decision(cmd, HOME, &empty()), GateDecision::RejectNonCanonical { .. }),
+                matches!(
+                    gate_decision(cmd, HOME, &empty()),
+                    GateDecision::RejectNonCanonical { .. }
+                ),
                 "should be non-canonical: {cmd}"
             );
         }
@@ -873,12 +1101,20 @@ mod tests {
     fn unlink_canonical_then_gated() {
         // unlink IS a canonical leader; the path is then gated by the tree logic.
         let d = gate_decision("unlink ~/Documents/taxes.pdf", HOME, &empty());
-        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
+        assert!(
+            matches!(d, GateDecision::RejectNeedsInspection { .. }),
+            "{:?}",
+            d
+        );
     }
     #[test]
     fn nondestructive_find_is_not_a_delete() {
         assert_eq!(
-            gate_decision("find ~/Library/Application\\ Support -name '*.log'", HOME, &empty()),
+            gate_decision(
+                "find ~/Library/Application\\ Support -name '*.log'",
+                HOME,
+                &empty()
+            ),
             GateDecision::Allow
         );
     }
@@ -892,43 +1128,144 @@ mod tests {
     #[test]
     fn relative_path_delete_is_non_canonical() {
         // The cd-then-relative bypass.
-        let d = gate_decision("cd ~ && rm -rf Library/Application\\ Support/Adobe", HOME, &empty());
-        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+        let d = gate_decision(
+            "cd ~ && rm -rf Library/Application\\ Support/Adobe",
+            HOME,
+            &empty(),
+        );
+        assert!(
+            matches!(d, GateDecision::RejectNonCanonical { .. }),
+            "{:?}",
+            d
+        );
     }
     #[test]
     fn command_substitution_delete_is_non_canonical() {
         let d = gate_decision("rm -rf $(cat ~/to-delete.txt)", HOME, &empty());
-        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+        assert!(
+            matches!(d, GateDecision::RejectNonCanonical { .. }),
+            "{:?}",
+            d
+        );
     }
     #[test]
     fn variable_operand_is_non_canonical() {
         let d = gate_decision("rm -rf $TARGET/cache", HOME, &empty());
-        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+        assert!(
+            matches!(d, GateDecision::RejectNonCanonical { .. }),
+            "{:?}",
+            d
+        );
     }
     #[test]
     fn pipe_in_delete_is_non_canonical() {
         let d = gate_decision("ls ~/Library | rm -rf ~/Library/Caches", HOME, &empty());
-        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+        assert!(
+            matches!(d, GateDecision::RejectNonCanonical { .. }),
+            "{:?}",
+            d
+        );
     }
     #[test]
     fn eval_is_non_canonical() {
-        let d = gate_decision("eval \"rm -rf ~/Library/Application Support\"", HOME, &empty());
-        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+        let d = gate_decision(
+            "eval \"rm -rf ~/Library/Application Support\"",
+            HOME,
+            &empty(),
+        );
+        assert!(
+            matches!(d, GateDecision::RejectNonCanonical { .. }),
+            "{:?}",
+            d
+        );
     }
     #[test]
     fn pipe_to_shell_is_non_canonical() {
         let d = gate_decision("echo cm0gLXJmIH4v | base64 -d | sh", HOME, &empty());
-        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+        assert!(
+            matches!(d, GateDecision::RejectNonCanonical { .. }),
+            "{:?}",
+            d
+        );
     }
     #[test]
     fn no_preserve_root_flag_is_non_canonical() {
         let d = gate_decision("rm -rf --no-preserve-root /tmp/x", HOME, &empty());
-        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+        assert!(
+            matches!(d, GateDecision::RejectNonCanonical { .. }),
+            "{:?}",
+            d
+        );
+    }
+    #[test]
+    fn wrapped_deletes_are_non_canonical() {
+        for cmd in [
+            "command rm -rf ~/Library/Application\\ Support/Adobe",
+            "env FOO=1 rm -rf ~/Library/Application\\ Support/Adobe",
+            "VAR=1 rm -rf ~/Library/Application\\ Support/Adobe",
+            "nice -n 10 rm -rf ~/Library/Application\\ Support/Adobe",
+        ] {
+            assert!(
+                matches!(
+                    gate_decision(cmd, HOME, &empty()),
+                    GateDecision::RejectNonCanonical { .. }
+                ),
+                "should reject wrapped delete: {cmd}"
+            );
+        }
+    }
+    #[test]
+    fn sudo_option_delete_still_hits_redline() {
+        let d = gate_decision(
+            "sudo -u root rm -rf ~/Library/Application\\ Support/Adobe",
+            HOME,
+            &empty(),
+        );
+        assert!(
+            matches!(d, GateDecision::RejectNeedsInspection { .. }),
+            "{:?}",
+            d
+        );
+    }
+    #[test]
+    fn nested_shell_deletes_are_non_canonical() {
+        for cmd in [
+            "bash -c 'rm -rf ~/Library/Application Support/Adobe'",
+            "zsh -lc 'find ~/Library/Application Support -delete'",
+            "sudo bash -c 'rm -rf /'",
+        ] {
+            assert!(
+                matches!(
+                    gate_decision(cmd, HOME, &empty()),
+                    GateDecision::RejectNonCanonical { .. }
+                ),
+                "should reject nested shell delete: {cmd}"
+            );
+        }
+    }
+    #[test]
+    fn dot_segment_operands_are_non_canonical() {
+        for cmd in [
+            "rm -rf ~/Library/Caches/../Application\\ Support/*",
+            "rm -rf /Users/fbob/Library/./Messages/Attachments",
+            "find ~/Library/Caches/../Application\\ Support -delete",
+        ] {
+            assert!(
+                matches!(
+                    gate_decision(cmd, HOME, &empty()),
+                    GateDecision::RejectNonCanonical { .. }
+                ),
+                "should reject dot-segment operand: {cmd}"
+            );
+        }
     }
     #[test]
     fn canonical_absolute_rm_outside_protected_allowed() {
         // The blessed form, in a safe location → just runs.
-        assert_eq!(gate_decision("rm -rf /tmp/build-cache", HOME, &empty()), GateDecision::Allow);
+        assert_eq!(
+            gate_decision("rm -rf /tmp/build-cache", HOME, &empty()),
+            GateDecision::Allow
+        );
     }
 
     // ── New protected trees ──────────────────────────────────────────────
@@ -964,7 +1301,11 @@ mod tests {
     fn specific_app_delete_allowed_after_inspecting_it() {
         let inspected = set(&["~/Library/Application Support/Adobe"]);
         assert_eq!(
-            gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected),
+            gate_decision(
+                "rm -rf ~/Library/Application\\ Support/Adobe",
+                HOME,
+                &inspected
+            ),
             GateDecision::Allow
         );
     }
@@ -972,7 +1313,11 @@ mod tests {
     fn specific_app_delete_allowed_after_inspecting_parent_tree() {
         let inspected = set(&["~/Library/Application Support"]);
         assert_eq!(
-            gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected),
+            gate_decision(
+                "rm -rf ~/Library/Application\\ Support/Adobe",
+                HOME,
+                &inspected
+            ),
             GateDecision::Allow
         );
     }
@@ -988,7 +1333,11 @@ mod tests {
     fn inspecting_home_does_not_clear_protected_child() {
         let inspected = set(&["~"]);
         assert!(matches!(
-            gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected),
+            gate_decision(
+                "rm -rf ~/Library/Application\\ Support/Adobe",
+                HOME,
+                &inspected
+            ),
             GateDecision::RejectNeedsInspection { .. }
         ));
     }
@@ -999,7 +1348,11 @@ mod tests {
             HOME,
             &empty(),
         );
-        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
+        assert!(
+            matches!(d, GateDecision::RejectNeedsInspection { .. }),
+            "{:?}",
+            d
+        );
     }
 
     // ── Regenerable: scoped to app trees only ────────────────────────────
@@ -1023,10 +1376,14 @@ mod tests {
         );
     }
     #[test]
-    fn cache_named_folder_under_documents_NOT_exempt() {
+    fn cache_named_folder_under_documents_not_exempt() {
         // The over-broad-hint hole: a user folder literally named "cache".
         let d = gate_decision("rm -rf ~/Documents/cache/report", HOME, &empty());
-        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
+        assert!(
+            matches!(d, GateDecision::RejectNeedsInspection { .. }),
+            "{:?}",
+            d
+        );
     }
 
     // ── Non-protected and non-delete: untouched ──────────────────────────
@@ -1121,14 +1478,22 @@ mod tests {
     #[test]
     fn careful_flow_inspect_then_delete_succeeds() {
         let mut inspected: HashSet<String> = HashSet::new();
-        let d1 = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected);
+        let d1 = gate_decision(
+            "rm -rf ~/Library/Application\\ Support/Adobe",
+            HOME,
+            &inspected,
+        );
         assert!(matches!(d1, GateDecision::RejectNeedsInspection { .. }));
 
         for p in inspected_paths("du -sh ~/Library/Application\\ Support/Adobe", HOME) {
             inspected.insert(p);
         }
 
-        let d2 = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected);
+        let d2 = gate_decision(
+            "rm -rf ~/Library/Application\\ Support/Adobe",
+            HOME,
+            &inspected,
+        );
         assert_eq!(d2, GateDecision::Allow);
     }
 }

--- a/crates/noah-tools/src/safety.rs
+++ b/crates/noah-tools/src/safety.rs
@@ -2,86 +2,140 @@
 //!
 //! See `apps/desktop/src-tauri/docs/safety-policy.md` for the full rationale.
 //! In short: deletions inside *protected trees* must be **inspected before
-//! deleted** (the Claude Code read-before-edit precedent), wildcard sweeps over
-//! those trees are rejected outright, and a tiny *hard-deny* floor refuses a
-//! handful of machine-ending actions even when reaffirmed.
+//! deleted** (the Claude Code read-before-edit precedent), sweeps over those
+//! trees (wildcards, or deleting the tree root / an ancestor) are rejected
+//! outright, and a tiny *hard-deny* floor refuses a handful of machine-ending
+//! actions even when reaffirmed.
 //!
 //! This module is **pure and deterministic**: it parses a command string and a
 //! set of already-inspected paths, and returns a verdict. State (the
 //! inspected-set) lives in the orchestrator, which mirrors the harness model —
 //! the tool stays stateless, the harness holds the gate.
+//!
+//! ## Quality of the approximation
+//!
+//! The whole value here is that the approximation is *good*. Verified facts
+//! baked into this module:
+//!
+//! - **Firmlinks**: every user path is also addressable under
+//!   `/System/Volumes/Data` (confirmed same inode on a live machine; see
+//!   `/usr/share/firmlinks`). We strip that prefix so the gate can't be
+//!   side-stepped by spelling the path the long way.
+//! - **Protected trees** track Apple's TCC-protected locations (Desktop,
+//!   Documents, Downloads, Mail, Messages, Safari, Contacts, Calendars,
+//!   Photos) plus credential stores (`~/.ssh`, `~/.gnupg`, cloud creds).
+//! - **Deletion vectors**: `rm`, `unlink`, and `find` (with `-delete`,
+//!   `-exec rm`, or piped to `xargs rm`) are all classified as deletes.
+//!
+//! Known, documented limits (consistent with "approximation, stated"): a
+//! relative path after an un-tracked `cd` is not resolved to home; and we do
+//! not model `$VAR` expansion beyond `$HOME`.
 
 use std::collections::HashSet;
 
+/// A protected location. `content` = true marks user-authored content trees
+/// (Documents, Photos…) where a cache/log name must NOT earn the regenerable
+/// exemption — a folder literally named "cache" under `~/Documents` is still
+/// the user's. `content` = false marks app-state/Library trees where
+/// cache/log subdirs are genuinely regenerable.
+pub struct ProtectedTree {
+    pub path: &'static str,
+    pub content: bool,
+}
+
+const fn app(path: &'static str) -> ProtectedTree {
+    ProtectedTree { path, content: false }
+}
+const fn content(path: &'static str) -> ProtectedTree {
+    ProtectedTree { path, content: true }
+}
+
 /// Protected trees — an approximation of "irreplaceable user data / app state."
-/// Deletions targeting these require prior inspection; wildcard sweeps over them
-/// are rejected. Stored tilde-rooted; matching expands `~` against the home dir.
-pub const PROTECTED_TREES: &[&str] = &[
-    "~/Library/Application Support",
-    "~/Library/Containers",
-    "~/Library/Group Containers",
-    "~/Library/Messages",
-    "~/Library/Mail",
-    "~/Library/Mobile Documents",
-    "~/Library/CloudStorage",
-    "~/Library/Photos",
-    "~/Pictures",
-    "~/Documents",
-    "~/Desktop",
-    "~/Movies",
-    "~/Music",
+/// Tilde-rooted; matching expands `~` against the home dir. Aligned with macOS
+/// TCC-protected locations + credential stores.
+pub const PROTECTED_TREES: &[ProtectedTree] = &[
+    // App state / Library (regenerable cache subdirs are exempt).
+    app("~/Library/Application Support"),
+    app("~/Library/Containers"),
+    app("~/Library/Group Containers"),
+    app("~/Library/Messages"),
+    app("~/Library/Mail"),
+    app("~/Library/Safari"),
+    app("~/Library/Calendars"),
+    app("~/Library/Mobile Documents"), // iCloud Drive
+    app("~/Library/CloudStorage"),     // Google Drive / Dropbox / OneDrive mounts
+    app("~/Library/Photos"),
+    // Credential / key stores (gated; Keychain itself is hard-deny).
+    app("~/.ssh"),
+    app("~/.gnupg"),
+    app("~/.aws"),
+    app("~/.kube"),
+    app("~/.docker"),
+    app("~/.config"),
+    // User content (no regenerable exemption).
+    content("~/Documents"),
+    content("~/Desktop"),
+    content("~/Pictures"),
+    content("~/Movies"),
+    content("~/Music"),
+    content("~/Downloads"),
 ];
 
-/// Path segments that mark regenerable data (caches/logs). A delete whose target
-/// contains one of these is treated as regenerable even inside a protected tree,
-/// so cache cleanup is never gated. Lowercased substring match.
+/// Path segments that mark regenerable data (caches/logs). A delete strictly
+/// inside an *app-state* protected tree whose path contains one of these is
+/// treated as regenerable → not gated. Lowercased substring match.
 pub const REGENERABLE_HINTS: &[&str] = &["/caches/", "/cache/", "/logs/", "/.cache/"];
 
-/// Read-class command leaders that count as *inspection*. Running one of these
-/// against a path records that path as inspected for the session.
-const INSPECT_LEADERS: &[&str] = &["ls", "du", "find", "stat", "cat", "file", "tree", "head", "tail"];
+/// Read-class command leaders that count as *inspection* (when not used
+/// destructively). Running one against a path records it as inspected.
+const INSPECT_LEADERS: &[&str] = &[
+    "ls", "du", "find", "stat", "cat", "file", "tree", "head", "tail", "wc", "grep",
+];
+
+/// Firmlink prefixes that re-address user data. Stripping these prevents the
+/// gate from being side-stepped via the long path. Lowercased.
+const FIRMLINK_PREFIXES: &[&str] = &["/system/volumes/data"];
 
 /// The verdict the harness acts on.
 #[derive(Debug, Clone, PartialEq)]
 pub enum GateDecision {
     /// Not a protected-tree delete (or it's regenerable). Proceed to normal flow.
     Allow,
-    /// Concrete delete inside a protected tree that hasn't been inspected.
-    /// Carries a tip instructing the model to inspect first.
+    /// Concrete delete of a specific path inside a protected tree that hasn't
+    /// been inspected. Carries a tip instructing the model to inspect first.
     RejectNeedsInspection { path: String, tip: String },
-    /// Wildcard sweep over a protected tree. Never auto-clears.
-    RejectWildcard { tree: String, tip: String },
+    /// Unbounded sweep over a protected tree — a wildcard, or deleting the tree
+    /// root / an ancestor of it. Never auto-clears; the model must enumerate.
+    RejectSweep { tree: String, tip: String },
     /// Machine-ending / identity-destroying action. Refused even if reaffirmed.
     HardDeny { reason: String },
 }
 
 impl GateDecision {
-    /// True when the harness should stop the action and feed the tip back to
-    /// the model instead of executing.
     pub fn is_rejection(&self) -> bool {
         !matches!(self, GateDecision::Allow)
     }
 
-    /// The classification label for telemetry.
     pub fn classification(&self) -> &'static str {
         match self {
             GateDecision::Allow => "allow",
             GateDecision::RejectNeedsInspection { .. } => "inspect_then_delete",
-            GateDecision::RejectWildcard { .. } => "reject_wildcard",
+            GateDecision::RejectSweep { .. } => "reject_sweep",
             GateDecision::HardDeny { .. } => "hard_deny",
         }
     }
 
-    /// The message shown to the model when rejected (empty for Allow).
     pub fn message(&self) -> String {
         match self {
             GateDecision::Allow => String::new(),
             GateDecision::RejectNeedsInspection { tip, .. } => tip.clone(),
-            GateDecision::RejectWildcard { tip, .. } => tip.clone(),
+            GateDecision::RejectSweep { tip, .. } => tip.clone(),
             GateDecision::HardDeny { reason } => reason.clone(),
         }
     }
 }
+
+// ── Normalisation ────────────────────────────────────────────────────────
 
 /// Expand a leading `~` or `$HOME` against `home`. Leaves other paths untouched.
 fn expand_home(path: &str, home: &str) -> String {
@@ -99,16 +153,33 @@ fn expand_home(path: &str, home: &str) -> String {
     }
 }
 
-/// Normalise for comparison: expand home, strip a trailing slash, lowercase
-/// (macOS default volumes are case-insensitive — matches `is_dangerous_command`).
+/// Strip a firmlink prefix (`/System/Volumes/Data`) so the long form of a user
+/// path matches the same tree as the short form. Operates on a lowercased path.
+fn strip_firmlink(lower: &str) -> String {
+    for prefix in FIRMLINK_PREFIXES {
+        if let Some(rest) = lower.strip_prefix(prefix) {
+            if rest.is_empty() {
+                return "/".to_string();
+            }
+            if rest.starts_with('/') {
+                return rest.to_string();
+            }
+        }
+    }
+    lower.to_string()
+}
+
+/// Normalise for comparison: expand home, lowercase (macOS default volumes are
+/// case-insensitive), strip the firmlink prefix, drop a trailing slash. Root
+/// `/` is preserved (not collapsed to empty).
 fn norm(path: &str, home: &str) -> String {
-    let expanded = expand_home(path, home);
-    let trimmed = expanded.trim_end_matches('/');
-    // Don't collapse root "/" (or "///") into an empty string.
-    if trimmed.is_empty() && expanded.starts_with('/') {
+    let expanded = expand_home(path, home).to_lowercase();
+    let stripped = strip_firmlink(&expanded);
+    let trimmed = stripped.trim_end_matches('/');
+    if trimmed.is_empty() && stripped.starts_with('/') {
         return "/".to_string();
     }
-    trimmed.to_lowercase()
+    trimmed.to_string()
 }
 
 /// True if `child` is `ancestor` or a descendant of it (both pre-normalised).
@@ -116,17 +187,49 @@ fn is_within(child: &str, ancestor: &str) -> bool {
     child == ancestor || child.starts_with(&format!("{}/", ancestor))
 }
 
-/// Does this path contain a glob metacharacter in a *path segment*? (We only
-/// care about `*`, `?`, `[` — the unbounded-expansion forms.)
-fn has_glob(path: &str) -> bool {
-    path.contains('*') || path.contains('?') || path.contains('[')
+fn has_glob(seg: &str) -> bool {
+    seg.contains('*') || seg.contains('?') || seg.contains('[')
 }
 
-/// Tokenise a single shell command into words, honouring backslash-escaped
-/// spaces (`Application\ Support`) and single/double quotes. This is a pragmatic
-/// tokenizer for *classification only*, not a full shell parser; it deliberately
-/// errs toward keeping a path together so we don't under-detect a protected
-/// target. Documented approximation — consistent with the policy.
+/// Split a path into the leading portion before the first glob-bearing segment,
+/// plus whether any glob was present. `~/Foo/*` -> (`~/Foo`, true);
+/// `~/Foo/App*/x` -> (`~/Foo`, true); `~/Foo/Bar` -> (`~/Foo/Bar`, false).
+fn base_and_glob(path: &str) -> (String, bool) {
+    let mut kept: Vec<&str> = Vec::new();
+    let mut glob = false;
+    // Preserve a leading "/" by tracking it separately.
+    let leading_slash = path.starts_with('/');
+    for seg in path.split('/') {
+        if seg.is_empty() {
+            continue;
+        }
+        if has_glob(seg) {
+            glob = true;
+            break;
+        }
+        kept.push(seg);
+    }
+    let joined = kept.join("/");
+    let base = if leading_slash {
+        format!("/{}", joined)
+    } else if path.starts_with('~') || path.starts_with('$') {
+        // keep the ~ / $HOME marker intact for expand_home downstream
+        if joined.is_empty() {
+            kept.first().map(|s| s.to_string()).unwrap_or_default()
+        } else {
+            joined
+        }
+    } else {
+        joined
+    };
+    (base, glob)
+}
+
+// ── Tokenising ─────────────────────────────────────────────────────────────
+
+/// Tokenise a single shell command honouring backslash-escaped spaces
+/// (`Application\ Support`) and single/double quotes. Pragmatic, classification-
+/// only; errs toward keeping a path whole so we don't under-detect a target.
 fn tokenize(cmd: &str) -> Vec<String> {
     let mut tokens = Vec::new();
     let mut cur = String::new();
@@ -169,9 +272,7 @@ fn tokenize(cmd: &str) -> Vec<String> {
     tokens
 }
 
-/// Split a compound command on `;`, `&&`, `||`, `|` into its constituent simple
-/// commands so a sequence (`rm a; rm b`) is classified per-part. Crude but
-/// sufficient: we only need the leaders and path operands of each part.
+/// Split a compound command on `;`, newline, `&&`, `||`, `|` into simple parts.
 fn split_commands(cmd: &str) -> Vec<String> {
     cmd.split(|c| c == ';' || c == '\n')
         .flat_map(|s| s.split("&&"))
@@ -182,13 +283,12 @@ fn split_commands(cmd: &str) -> Vec<String> {
         .collect()
 }
 
-/// The leader of a simple command, with a leading `sudo` stripped.
+/// Leader of a simple command, with a leading `sudo` (and its flags) stripped.
 fn leader_and_args(part: &str) -> (String, Vec<String>) {
     let toks = tokenize(part);
     let mut idx = 0;
-    if toks.get(0).map(|s| s.as_str()) == Some("sudo") {
+    if toks.first().map(|s| s.as_str()) == Some("sudo") {
         idx = 1;
-        // skip sudo flags like -S, -n
         while toks.get(idx).map(|s| s.starts_with('-')).unwrap_or(false) {
             idx += 1;
         }
@@ -198,61 +298,130 @@ fn leader_and_args(part: &str) -> (String, Vec<String>) {
     (leader, args)
 }
 
-/// Path operands of a command (non-flag tokens after the leader).
+/// Non-flag operands (for `rm`/`unlink`).
 fn path_operands(args: &[String]) -> Vec<String> {
-    args.iter()
-        .filter(|a| !a.starts_with('-'))
-        .cloned()
-        .collect()
+    args.iter().filter(|a| !a.starts_with('-')).cloned().collect()
 }
 
-/// Hard-deny floor: machine-ending or identity-destroying actions, refused even
-/// with inspection and reaffirmation. Returns the refusal reason.
-pub fn hard_denied(cmd: &str, home: &str) -> Option<String> {
-    for part in split_commands(cmd) {
-        let (leader, args) = leader_and_args(&part);
-        let operands = path_operands(&args);
+/// Leading path operands of a `find` (before the first predicate/flag/`(`/`!`).
+fn find_roots(args: &[String]) -> Vec<String> {
+    let mut roots = Vec::new();
+    for a in args {
+        if a.starts_with('-') || a == "(" || a == "!" {
+            break;
+        }
+        roots.push(a.clone());
+    }
+    roots
+}
 
-        if leader == "rm" {
-            for op in &operands {
-                let n = norm(op, home);
-                // root / system / whole-Users wipes
-                if n == "/" || n == "/system" || n.starts_with("/system/")
-                    || n == "/users" || n == "/usr" || n.starts_with("/usr/")
-                {
-                    return Some(format!(
-                        "Refused: `{}` would damage the operating system itself. \
-                         This is a hard limit — Noah will not run it even if asked. \
-                         If the goal is free space, target user caches and large \
-                         files instead.",
-                        op
-                    ));
-                }
-                // auth / identity stores
-                let home_l = home.trim_end_matches('/').to_lowercase();
-                if n.starts_with(&format!("{}/library/keychains", home_l))
-                    || n.contains("/com.apple.tcc")
-                    || n.contains("com.apple.security")
-                {
-                    return Some(
-                        "Refused: this targets your Keychain / security identity. \
-                         Deleting it would lock you out of saved passwords and app \
-                         logins, irrecoverably. This is a hard limit."
-                            .to_string(),
-                    );
+/// Does this `find` arg list delete (`-delete`, `-exec rm/unlink`, `-execdir …`)?
+fn find_args_destructive(args: &[String]) -> bool {
+    for (i, a) in args.iter().enumerate() {
+        if a == "-delete" {
+            return true;
+        }
+        if a == "-exec" || a == "-execdir" {
+            if let Some(next) = args.get(i + 1) {
+                let n = next.trim_start_matches("./");
+                if n == "rm" || n == "unlink" || n == "srm" {
+                    return true;
                 }
             }
         }
+    }
+    false
+}
 
-        // secure-erase of a disk
+/// Whole-command: is there an `xargs` that runs `rm`/`unlink`? (the `find | xargs
+/// rm` vector). Used to treat preceding `find` roots as delete targets.
+fn has_xargs_rm(cmd: &str) -> bool {
+    for part in split_commands(cmd) {
+        let (leader, args) = leader_and_args(&part);
+        if leader == "xargs" {
+            if args.iter().any(|a| {
+                let n = a.trim_start_matches("./");
+                n == "rm" || n == "unlink" || n == "srm"
+            }) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// All raw path operands a command would delete, across every vector. Not
+/// normalised — caller normalises as needed.
+fn delete_targets_raw(cmd: &str) -> Vec<String> {
+    let xargs_rm = has_xargs_rm(cmd);
+    let mut out = Vec::new();
+    for part in split_commands(cmd) {
+        let (leader, args) = leader_and_args(&part);
+        match leader.as_str() {
+            "rm" | "unlink" | "srm" => out.extend(path_operands(&args)),
+            "find" => {
+                if find_args_destructive(&args) || xargs_rm {
+                    out.extend(find_roots(&args));
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+// ── Hard-deny floor ──────────────────────────────────────────────────────
+
+/// Machine-ending or identity-destroying actions, refused even with inspection
+/// and reaffirmation. Returns the refusal reason.
+pub fn hard_denied(cmd: &str, home: &str) -> Option<String> {
+    let home_n = norm(home, home);
+    for op in delete_targets_raw(cmd) {
+        let n = norm(&op, home);
+        // root / system / whole-Users / home-root wipes
+        if n == "/"
+            || n == "/system"
+            || n.starts_with("/system/")
+            || n == "/users"
+            || n == "/usr"
+            || n.starts_with("/usr/")
+            || n == "/library"
+            || n == home_n
+        {
+            return Some(format!(
+                "Refused: `{}` would wipe the operating system or your entire home \
+                 folder. This is a hard limit — Noah will not run it even if asked. \
+                 To free space, target specific caches and large files instead.",
+                op
+            ));
+        }
+        // auth / identity stores
+        if n.starts_with(&format!("{}/library/keychains", home_n))
+            || n == format!("{}/library/keychains", home_n)
+            || n.contains("/com.apple.tcc")
+            || n.contains("com.apple.security")
+        {
+            return Some(
+                "Refused: this targets your Keychain / security identity — deleting \
+                 it would lock you out of saved passwords and app logins, \
+                 irrecoverably. This is a hard limit."
+                    .to_string(),
+            );
+        }
+    }
+    // secure-erase of a disk
+    for part in split_commands(cmd) {
+        let (leader, args) = leader_and_args(&part);
         if leader == "diskutil" {
             let joined = args.join(" ").to_lowercase();
-            if joined.contains("erasedisk") || joined.contains("erasevolume")
-                || joined.contains("securerase") || joined.contains("zerodisk")
+            if joined.contains("erasedisk")
+                || joined.contains("erasevolume")
+                || joined.contains("securerase")
+                || joined.contains("zerodisk")
             {
                 return Some(
-                    "Refused: erasing a disk/volume is irreversible and outside \
-                     what storage cleanup should ever do. This is a hard limit."
+                    "Refused: erasing a disk/volume is irreversible and outside what \
+                     storage cleanup should ever do. This is a hard limit."
                         .to_string(),
                 );
             }
@@ -261,80 +430,79 @@ pub fn hard_denied(cmd: &str, home: &str) -> Option<String> {
     None
 }
 
+// ── The gate ─────────────────────────────────────────────────────────────
+
 /// Classify a command against the inspected-set and return the gate decision.
 ///
-/// `inspected` holds normalised (expanded, lowercased, trailing-slash-stripped)
-/// paths recorded by prior read-class observations this session.
+/// `inspected` holds normalised paths recorded by prior read-class observations.
 pub fn gate_decision(cmd: &str, home: &str, inspected: &HashSet<String>) -> GateDecision {
     if let Some(reason) = hard_denied(cmd, home) {
         return GateDecision::HardDeny { reason };
     }
 
-    for part in split_commands(cmd) {
-        let (leader, args) = leader_and_args(&part);
-        if leader != "rm" {
-            continue;
-        }
-        for op in path_operands(&args) {
-            let n = norm(&op, home);
+    for op in delete_targets_raw(cmd) {
+        let (base, is_glob) = base_and_glob(&op);
+        let nbase = norm(&base, home);
+        let nop = norm(&op, home);
 
-            // Regenerable (cache/log) → never gated.
-            if REGENERABLE_HINTS.iter().any(|h| n.contains(h)) {
+        for tree in PROTECTED_TREES {
+            let ntree = norm(tree.path, home);
+            let within = is_within(&nbase, &ntree); // base at-or-below tree
+            let contains = is_within(&ntree, &nbase); // base is tree or its ancestor
+            if !within && !contains {
                 continue;
             }
 
-            // Which protected tree (if any) does this operand fall in?
-            let tree = PROTECTED_TREES.iter().find_map(|t| {
-                let tn = norm(t, home);
-                if is_within(&n, &tn) {
-                    Some(tn)
-                } else {
-                    None
-                }
-            });
-            let Some(tree) = tree else { continue };
+            // Regenerable cache/log strictly inside an app-state tree → not gated.
+            let strictly_inside = within && !contains;
+            if strictly_inside
+                && !tree.content
+                && REGENERABLE_HINTS.iter().any(|h| nop.contains(h))
+            {
+                break; // this operand is fine; move to next operand
+            }
 
-            // Wildcard sweep over a protected tree → never clears.
-            if has_glob(&op) {
-                return GateDecision::RejectWildcard {
-                    tree: tree.clone(),
+            // Unbounded: a wildcard, or deleting the tree root / an ancestor.
+            if is_glob || contains {
+                return GateDecision::RejectSweep {
+                    tree: ntree.clone(),
                     tip: format!(
-                        "Held back: `{}` is a wildcard delete over a protected \
-                         folder, which removes whatever happens to be inside \
-                         (including data you can't get back). Instead: inspect \
-                         the folder (e.g. `du -sh '{}'/*`), then delete the \
-                         specific subdirectories you've confirmed are safe — one \
-                         explicit path at a time.",
-                        op, tree
+                        "Held back: `{}` would remove a protected folder's entire \
+                         contents (or the folder itself) — an unbounded delete that \
+                         includes data you may not be able to get back. Instead: \
+                         inspect it (e.g. `du -sh '{}'/*`), then delete the specific \
+                         subdirectories you've confirmed are safe, one explicit path \
+                         at a time.",
+                        op, ntree
                     ),
                 };
             }
 
-            // Concrete path: cleared only if inspected within the tree.
-            let cleared = inspected.iter().any(|i| {
-                is_within(i, &tree) && is_within(&n, i)
-            });
+            // Concrete path inside a protected tree: cleared only if inspected.
+            let cleared = inspected
+                .iter()
+                .any(|i| is_within(i, &ntree) && is_within(&nbase, i));
             if !cleared {
                 return GateDecision::RejectNeedsInspection {
-                    path: n.clone(),
+                    path: nbase.clone(),
                     tip: format!(
-                        "Held back: `{}` is inside a protected folder and Noah \
-                         hasn't looked at it yet. Inspect it first (e.g. \
-                         `ls -la '{}'` or `du -sh '{}'`) and confirm what it is \
-                         and that it's safe to remove, then retry this exact \
-                         delete.",
+                        "Held back: `{}` is inside a protected folder and Noah hasn't \
+                         looked at it yet. Inspect it first (e.g. `ls -la '{}'` or \
+                         `du -sh '{}'`), confirm what it is and that it's safe to \
+                         remove, then retry this exact delete.",
                         op, op, op
                     ),
                 };
             }
+            break; // cleared for this tree; next operand
         }
     }
 
     GateDecision::Allow
 }
 
-/// Paths that a command inspects, normalised, to fold into the session
-/// inspected-set. Empty unless the command is a read-class observation.
+/// Paths a command inspects, normalised, to fold into the session inspected-set.
+/// Empty unless the command is a non-destructive read-class observation.
 pub fn inspected_paths(cmd: &str, home: &str) -> Vec<String> {
     let mut out = Vec::new();
     for part in split_commands(cmd) {
@@ -342,14 +510,20 @@ pub fn inspected_paths(cmd: &str, home: &str) -> Vec<String> {
         if !INSPECT_LEADERS.contains(&leader.as_str()) {
             continue;
         }
-        for op in path_operands(&args) {
-            // Record the directory being listed. Strip a trailing `/*` or `/.`
-            // so `du -sh ~/Foo/*` records `~/Foo` (you saw its children).
-            let base = op
-                .trim_end_matches("/*")
-                .trim_end_matches("/.")
-                .trim_end_matches("/*/");
-            let n = norm(base, home);
+        // A destructive find is a delete, not a look.
+        if leader == "find" && (find_args_destructive(&args) || has_xargs_rm(cmd)) {
+            continue;
+        }
+        let operands = if leader == "find" {
+            find_roots(&args)
+        } else {
+            path_operands(&args)
+        };
+        for op in operands {
+            // Record the directory being observed; strip a trailing glob segment
+            // (`du -sh ~/Foo/*` means you saw ~/Foo's children).
+            let (base, _) = base_and_glob(&op);
+            let n = norm(&base, home);
             if !n.is_empty() && n != "/" {
                 out.push(n);
             }
@@ -367,62 +541,192 @@ mod tests {
     fn set(paths: &[&str]) -> HashSet<String> {
         paths.iter().map(|p| norm(p, HOME)).collect()
     }
-
-    // ── The incident commands: every one of these must be held back ──────
-
-    #[test]
-    fn incident_wildcard_app_support_rejected() {
-        let d = gate_decision("rm -rf ~/Library/Application\\ Support/*", HOME, &set(&[]));
-        assert!(matches!(d, GateDecision::RejectWildcard { .. }), "{:?}", d);
+    fn empty() -> HashSet<String> {
+        HashSet::new()
     }
 
+    // ── The incident commands: every one held back ───────────────────────
+
     #[test]
-    fn incident_sudo_wildcard_app_support_rejected() {
-        let d = gate_decision("sudo rm -rf ~/Library/Application\\ Support/*", HOME, &set(&[]));
-        assert!(matches!(d, GateDecision::RejectWildcard { .. }), "{:?}", d);
+    fn incident_wildcard_app_support() {
+        assert!(matches!(
+            gate_decision("rm -rf ~/Library/Application\\ Support/*", HOME, &empty()),
+            GateDecision::RejectSweep { .. }
+        ));
+    }
+    #[test]
+    fn incident_sudo_wildcard_app_support() {
+        assert!(matches!(
+            gate_decision("sudo rm -rf ~/Library/Application\\ Support/*", HOME, &empty()),
+            GateDecision::RejectSweep { .. }
+        ));
+    }
+    #[test]
+    fn incident_wildcard_containers() {
+        assert!(matches!(
+            gate_decision("rm -rf ~/Library/Containers/*", HOME, &empty()),
+            GateDecision::RejectSweep { .. }
+        ));
+    }
+    #[test]
+    fn incident_messages_container_specific() {
+        assert!(matches!(
+            gate_decision("rm -rf ~/Library/Containers/com.apple.MobileSMS", HOME, &empty()),
+            GateDecision::RejectNeedsInspection { .. }
+        ));
+    }
+    #[test]
+    fn incident_messages_attachments_wildcard() {
+        assert!(matches!(
+            gate_decision("rm -rf ~/Library/Messages/Attachments/*", HOME, &empty()),
+            GateDecision::RejectSweep { .. }
+        ));
+    }
+    #[test]
+    fn incident_group_containers_wildcard() {
+        assert!(matches!(
+            gate_decision("rm -rf ~/Library/Group\\ Containers/*", HOME, &empty()),
+            GateDecision::RejectSweep { .. }
+        ));
     }
 
-    #[test]
-    fn incident_wildcard_containers_rejected() {
-        let d = gate_decision("rm -rf ~/Library/Containers/*", HOME, &set(&[]));
-        assert!(matches!(d, GateDecision::RejectWildcard { .. }), "{:?}", d);
-    }
+    // ── Firmlink bypass (the long path) ──────────────────────────────────
 
     #[test]
-    fn incident_messages_container_rejected_uninspected() {
-        let d = gate_decision("rm -rf ~/Library/Containers/com.apple.MobileSMS", HOME, &set(&[]));
-        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
-    }
-
-    #[test]
-    fn incident_messages_attachments_wildcard_rejected() {
-        let d = gate_decision("rm -rf ~/Library/Messages/Attachments/*", HOME, &set(&[]));
-        assert!(matches!(d, GateDecision::RejectWildcard { .. }), "{:?}", d);
-    }
-
-    #[test]
-    fn incident_group_containers_wildcard_rejected() {
-        let d = gate_decision("rm -rf ~/Library/Group\\ Containers/*", HOME, &set(&[]));
-        assert!(matches!(d, GateDecision::RejectWildcard { .. }), "{:?}", d);
-    }
-
-    // ── The unroll bypass: specific deletes still need inspection ─────────
-
-    #[test]
-    fn unrolled_specific_app_delete_rejected_without_inspection() {
-        // The exact bypass from the trace: enumerate instead of wildcard.
-        let d = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &set(&[]));
-        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
-    }
-
-    #[test]
-    fn sequence_of_specific_deletes_rejected_at_first_uninspected() {
+    fn firmlink_wildcard_rejected() {
+        // The exact long-form prefix the real trace used for du.
         let d = gate_decision(
-            "rm -rf ~/Library/Application\\ Support/Adobe; rm -rf ~/Library/Application\\ Support/obs-studio",
+            "rm -rf /System/Volumes/Data/Users/fbob/Library/Application\\ Support/*",
             HOME,
-            &set(&[]),
+            &empty(),
+        );
+        assert!(matches!(d, GateDecision::RejectSweep { .. }), "{:?}", d);
+    }
+    #[test]
+    fn firmlink_specific_rejected_uninspected() {
+        let d = gate_decision(
+            "rm -rf /System/Volumes/Data/Users/fbob/Library/Application\\ Support/Adobe",
+            HOME,
+            &empty(),
         );
         assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
+    }
+    #[test]
+    fn firmlink_inspection_clears_firmlink_delete() {
+        // Inspect via short path, delete via long path → still cleared (same inode).
+        let inspected = set(&["~/Library/Application Support/Adobe"]);
+        let d = gate_decision(
+            "rm -rf /System/Volumes/Data/Users/fbob/Library/Application\\ Support/Adobe",
+            HOME,
+            &inspected,
+        );
+        assert_eq!(d, GateDecision::Allow);
+    }
+
+    // ── Ancestor / whole-tree sweeps ─────────────────────────────────────
+
+    #[test]
+    fn deleting_library_ancestor_rejected() {
+        // ~/Library is an ancestor of every protected tree.
+        let d = gate_decision("rm -rf ~/Library", HOME, &empty());
+        assert!(matches!(d, GateDecision::RejectSweep { .. }), "{:?}", d);
+    }
+    #[test]
+    fn deleting_whole_tree_root_rejected_even_inspected() {
+        let inspected = set(&["~/Library/Application Support"]);
+        let d = gate_decision("rm -rf ~/Library/Application\\ Support", HOME, &inspected);
+        assert!(matches!(d, GateDecision::RejectSweep { .. }), "{:?}", d);
+    }
+    #[test]
+    fn deleting_home_is_hard_deny() {
+        assert!(matches!(
+            gate_decision("rm -rf ~", HOME, &empty()),
+            GateDecision::HardDeny { .. }
+        ));
+        assert!(matches!(
+            gate_decision("rm -rf /Users/fbob", HOME, &empty()),
+            GateDecision::HardDeny { .. }
+        ));
+    }
+
+    // ── find / xargs / unlink vectors ────────────────────────────────────
+
+    #[test]
+    fn find_delete_in_protected_tree_rejected() {
+        let d = gate_decision(
+            "find ~/Library/Application\\ Support -maxdepth 1 -type d -delete",
+            HOME,
+            &empty(),
+        );
+        assert!(matches!(d, GateDecision::RejectSweep { .. }), "{:?}", d);
+    }
+    #[test]
+    fn find_exec_rm_in_protected_tree_rejected() {
+        let d = gate_decision(
+            "find ~/Library/Containers/com.apple.MobileSMS -exec rm -rf {} +",
+            HOME,
+            &empty(),
+        );
+        // Concrete subdir of Containers → inspect-gate.
+        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
+    }
+    #[test]
+    fn find_pipe_xargs_rm_rejected() {
+        let d = gate_decision(
+            "find ~/Library/Application\\ Support -name '*' | xargs rm -rf",
+            HOME,
+            &empty(),
+        );
+        assert!(matches!(d, GateDecision::RejectSweep { .. }), "{:?}", d);
+    }
+    #[test]
+    fn unlink_in_protected_tree_gated() {
+        let d = gate_decision("unlink ~/Documents/taxes.pdf", HOME, &empty());
+        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
+    }
+    #[test]
+    fn nondestructive_find_is_not_a_delete() {
+        let d = gate_decision(
+            "find ~/Library/Application\\ Support -name '*.log'",
+            HOME,
+            &empty(),
+        );
+        assert_eq!(d, GateDecision::Allow);
+    }
+    #[test]
+    fn destructive_find_does_not_count_as_inspection() {
+        assert!(inspected_paths(
+            "find ~/Library/Application\\ Support -delete",
+            HOME
+        )
+        .is_empty());
+    }
+
+    // ── New protected trees ──────────────────────────────────────────────
+
+    #[test]
+    fn ssh_keys_gated() {
+        assert!(matches!(
+            gate_decision("rm -rf ~/.ssh", HOME, &empty()),
+            GateDecision::RejectSweep { .. } // whole-tree root
+        ));
+        assert!(matches!(
+            gate_decision("rm -f ~/.ssh/id_ed25519", HOME, &empty()),
+            GateDecision::RejectNeedsInspection { .. }
+        ));
+    }
+    #[test]
+    fn downloads_and_safari_and_calendars_gated() {
+        for cmd in [
+            "rm -rf ~/Downloads/old",
+            "rm -rf ~/Library/Safari/History.db",
+            "rm -rf ~/Library/Calendars/x",
+        ] {
+            assert!(
+                gate_decision(cmd, HOME, &empty()).is_rejection(),
+                "should gate: {cmd}"
+            );
+        }
     }
 
     // ── "Be my guest": inspected → allowed ───────────────────────────────
@@ -430,139 +734,171 @@ mod tests {
     #[test]
     fn specific_app_delete_allowed_after_inspecting_it() {
         let inspected = set(&["~/Library/Application Support/Adobe"]);
-        let d = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected);
-        assert_eq!(d, GateDecision::Allow);
+        assert_eq!(
+            gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected),
+            GateDecision::Allow
+        );
     }
-
     #[test]
     fn specific_app_delete_allowed_after_inspecting_parent_tree() {
-        // Listing the tree root clears its descendants (you saw the listing).
         let inspected = set(&["~/Library/Application Support"]);
-        let d = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected);
-        assert_eq!(d, GateDecision::Allow);
+        assert_eq!(
+            gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected),
+            GateDecision::Allow
+        );
     }
-
     #[test]
     fn wildcard_never_clears_even_after_inspection() {
-        // Even having looked, the unbounded sweep stays rejected — enumerate.
         let inspected = set(&["~/Library/Application Support"]);
-        let d = gate_decision("rm -rf ~/Library/Application\\ Support/*", HOME, &inspected);
-        assert!(matches!(d, GateDecision::RejectWildcard { .. }), "{:?}", d);
+        assert!(matches!(
+            gate_decision("rm -rf ~/Library/Application\\ Support/*", HOME, &inspected),
+            GateDecision::RejectSweep { .. }
+        ));
     }
-
     #[test]
     fn inspecting_home_does_not_clear_protected_child() {
-        // `ls ~` is above the tree root → clears nothing inside it.
         let inspected = set(&["~"]);
-        let d = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected);
+        assert!(matches!(
+            gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected),
+            GateDecision::RejectNeedsInspection { .. }
+        ));
+    }
+    #[test]
+    fn unrolled_sequence_rejected_at_first_uninspected() {
+        let d = gate_decision(
+            "rm -rf ~/Library/Application\\ Support/Adobe; rm -rf ~/Library/Application\\ Support/obs-studio",
+            HOME,
+            &empty(),
+        );
         assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
     }
 
-    // ── Regenerable: caches/logs never gated ─────────────────────────────
+    // ── Regenerable: scoped to app trees only ────────────────────────────
 
     #[test]
-    fn caches_wildcard_allowed() {
-        let d = gate_decision("rm -rf ~/Library/Caches/*", HOME, &set(&[]));
-        assert_eq!(d, GateDecision::Allow);
+    fn caches_wildcard_outside_protected_allowed() {
+        assert_eq!(
+            gate_decision("rm -rf ~/Library/Caches/*", HOME, &empty()),
+            GateDecision::Allow
+        );
     }
-
     #[test]
     fn app_support_cache_subdir_allowed() {
-        let d = gate_decision(
-            "rm -rf ~/Library/Application\\ Support/Foo/Caches/blobs",
-            HOME,
-            &set(&[]),
+        assert_eq!(
+            gate_decision(
+                "rm -rf ~/Library/Application\\ Support/Foo/Caches/blobs",
+                HOME,
+                &empty()
+            ),
+            GateDecision::Allow
         );
-        assert_eq!(d, GateDecision::Allow);
     }
-
     #[test]
-    fn logs_allowed() {
-        let d = gate_decision("rm -rf ~/Library/Logs/old", HOME, &set(&[]));
-        assert_eq!(d, GateDecision::Allow);
+    fn cache_named_folder_under_documents_NOT_exempt() {
+        // The over-broad-hint hole: a user folder literally named "cache".
+        let d = gate_decision("rm -rf ~/Documents/cache/report", HOME, &empty());
+        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
     }
 
     // ── Non-protected and non-delete: untouched ──────────────────────────
 
     #[test]
     fn delete_outside_protected_tree_allowed() {
-        let d = gate_decision("rm -rf ~/Downloads/installer.dmg", HOME, &set(&[]));
-        assert_eq!(d, GateDecision::Allow);
+        assert_eq!(
+            gate_decision("rm -rf ~/.npm/_cacache", HOME, &empty()),
+            GateDecision::Allow
+        );
     }
-
     #[test]
     fn non_rm_command_allowed() {
-        let d = gate_decision("du -sh ~/Library/Application\\ Support/*", HOME, &set(&[]));
-        assert_eq!(d, GateDecision::Allow);
+        assert_eq!(
+            gate_decision("du -sh ~/Library/Application\\ Support/*", HOME, &empty()),
+            GateDecision::Allow
+        );
     }
 
     // ── Hard-deny floor ──────────────────────────────────────────────────
 
     #[test]
     fn rm_root_hard_denied() {
-        let d = gate_decision("rm -rf /", HOME, &set(&[]));
-        assert!(matches!(d, GateDecision::HardDeny { .. }), "{:?}", d);
+        assert!(matches!(
+            gate_decision("rm -rf /", HOME, &empty()),
+            GateDecision::HardDeny { .. }
+        ));
     }
-
     #[test]
     fn rm_system_hard_denied() {
-        let d = gate_decision("sudo rm -rf /System", HOME, &set(&[]));
-        assert!(matches!(d, GateDecision::HardDeny { .. }), "{:?}", d);
+        assert!(matches!(
+            gate_decision("sudo rm -rf /System", HOME, &empty()),
+            GateDecision::HardDeny { .. }
+        ));
     }
-
+    #[test]
+    fn firmlink_root_hard_denied() {
+        assert!(matches!(
+            gate_decision("rm -rf /System/Volumes/Data/Users/fbob", HOME, &empty()),
+            GateDecision::HardDeny { .. }
+        ));
+    }
     #[test]
     fn keychain_hard_denied_even_if_inspected() {
         let inspected = set(&["~/Library/Keychains"]);
-        let d = gate_decision("rm -rf ~/Library/Keychains", HOME, &inspected);
-        assert!(matches!(d, GateDecision::HardDeny { .. }), "{:?}", d);
+        assert!(matches!(
+            gate_decision("rm -rf ~/Library/Keychains", HOME, &inspected),
+            GateDecision::HardDeny { .. }
+        ));
     }
-
     #[test]
     fn diskutil_erase_hard_denied() {
-        let d = gate_decision("diskutil eraseDisk APFS Blank disk0", HOME, &set(&[]));
-        assert!(matches!(d, GateDecision::HardDeny { .. }), "{:?}", d);
+        assert!(matches!(
+            gate_decision("diskutil eraseDisk APFS Blank disk0", HOME, &empty()),
+            GateDecision::HardDeny { .. }
+        ));
     }
 
     // ── inspected_paths extraction ───────────────────────────────────────
 
     #[test]
     fn inspected_paths_records_du_target() {
-        let p = inspected_paths("du -sh ~/Library/Application\\ Support/Adobe", HOME);
-        assert_eq!(p, vec![norm("~/Library/Application Support/Adobe", HOME)]);
+        assert_eq!(
+            inspected_paths("du -sh ~/Library/Application\\ Support/Adobe", HOME),
+            vec![norm("~/Library/Application Support/Adobe", HOME)]
+        );
     }
-
     #[test]
     fn inspected_paths_strips_trailing_wildcard() {
-        let p = inspected_paths("du -sh ~/Library/Application\\ Support/*", HOME);
-        assert_eq!(p, vec![norm("~/Library/Application Support", HOME)]);
+        assert_eq!(
+            inspected_paths("du -sh ~/Library/Application\\ Support/*", HOME),
+            vec![norm("~/Library/Application Support", HOME)]
+        );
     }
-
     #[test]
-    fn inspected_paths_handles_ls() {
-        let p = inspected_paths("ls -la ~/Library/Containers/com.apple.MobileSMS", HOME);
-        assert_eq!(p, vec![norm("~/Library/Containers/com.apple.MobileSMS", HOME)]);
+    fn inspected_paths_handles_firmlink() {
+        assert_eq!(
+            inspected_paths(
+                "ls -la /System/Volumes/Data/Users/fbob/Library/Containers/com.apple.MobileSMS",
+                HOME
+            ),
+            vec![norm("~/Library/Containers/com.apple.MobileSMS", HOME)]
+        );
     }
-
     #[test]
     fn inspected_paths_empty_for_rm() {
         assert!(inspected_paths("rm -rf ~/Library/Caches/*", HOME).is_empty());
     }
 
-    // ── End-to-end: the careful path the harness is meant to produce ─────
+    // ── End-to-end careful path ──────────────────────────────────────────
 
     #[test]
     fn careful_flow_inspect_then_delete_succeeds() {
-        // 1. Blind delete is rejected.
         let mut inspected: HashSet<String> = HashSet::new();
         let d1 = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected);
         assert!(matches!(d1, GateDecision::RejectNeedsInspection { .. }));
 
-        // 2. Model inspects (as the tip instructs).
         for p in inspected_paths("du -sh ~/Library/Application\\ Support/Adobe", HOME) {
             inspected.insert(p);
         }
 
-        // 3. Retry now clears — be my guest.
         let d2 = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected);
         assert_eq!(d2, GateDecision::Allow);
     }

--- a/crates/noah-tools/src/safety.rs
+++ b/crates/noah-tools/src/safety.rs
@@ -1,0 +1,569 @@
+//! Destructive-action safety policy — the enforced redline layer.
+//!
+//! See `apps/desktop/src-tauri/docs/safety-policy.md` for the full rationale.
+//! In short: deletions inside *protected trees* must be **inspected before
+//! deleted** (the Claude Code read-before-edit precedent), wildcard sweeps over
+//! those trees are rejected outright, and a tiny *hard-deny* floor refuses a
+//! handful of machine-ending actions even when reaffirmed.
+//!
+//! This module is **pure and deterministic**: it parses a command string and a
+//! set of already-inspected paths, and returns a verdict. State (the
+//! inspected-set) lives in the orchestrator, which mirrors the harness model —
+//! the tool stays stateless, the harness holds the gate.
+
+use std::collections::HashSet;
+
+/// Protected trees — an approximation of "irreplaceable user data / app state."
+/// Deletions targeting these require prior inspection; wildcard sweeps over them
+/// are rejected. Stored tilde-rooted; matching expands `~` against the home dir.
+pub const PROTECTED_TREES: &[&str] = &[
+    "~/Library/Application Support",
+    "~/Library/Containers",
+    "~/Library/Group Containers",
+    "~/Library/Messages",
+    "~/Library/Mail",
+    "~/Library/Mobile Documents",
+    "~/Library/CloudStorage",
+    "~/Library/Photos",
+    "~/Pictures",
+    "~/Documents",
+    "~/Desktop",
+    "~/Movies",
+    "~/Music",
+];
+
+/// Path segments that mark regenerable data (caches/logs). A delete whose target
+/// contains one of these is treated as regenerable even inside a protected tree,
+/// so cache cleanup is never gated. Lowercased substring match.
+pub const REGENERABLE_HINTS: &[&str] = &["/caches/", "/cache/", "/logs/", "/.cache/"];
+
+/// Read-class command leaders that count as *inspection*. Running one of these
+/// against a path records that path as inspected for the session.
+const INSPECT_LEADERS: &[&str] = &["ls", "du", "find", "stat", "cat", "file", "tree", "head", "tail"];
+
+/// The verdict the harness acts on.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GateDecision {
+    /// Not a protected-tree delete (or it's regenerable). Proceed to normal flow.
+    Allow,
+    /// Concrete delete inside a protected tree that hasn't been inspected.
+    /// Carries a tip instructing the model to inspect first.
+    RejectNeedsInspection { path: String, tip: String },
+    /// Wildcard sweep over a protected tree. Never auto-clears.
+    RejectWildcard { tree: String, tip: String },
+    /// Machine-ending / identity-destroying action. Refused even if reaffirmed.
+    HardDeny { reason: String },
+}
+
+impl GateDecision {
+    /// True when the harness should stop the action and feed the tip back to
+    /// the model instead of executing.
+    pub fn is_rejection(&self) -> bool {
+        !matches!(self, GateDecision::Allow)
+    }
+
+    /// The classification label for telemetry.
+    pub fn classification(&self) -> &'static str {
+        match self {
+            GateDecision::Allow => "allow",
+            GateDecision::RejectNeedsInspection { .. } => "inspect_then_delete",
+            GateDecision::RejectWildcard { .. } => "reject_wildcard",
+            GateDecision::HardDeny { .. } => "hard_deny",
+        }
+    }
+
+    /// The message shown to the model when rejected (empty for Allow).
+    pub fn message(&self) -> String {
+        match self {
+            GateDecision::Allow => String::new(),
+            GateDecision::RejectNeedsInspection { tip, .. } => tip.clone(),
+            GateDecision::RejectWildcard { tip, .. } => tip.clone(),
+            GateDecision::HardDeny { reason } => reason.clone(),
+        }
+    }
+}
+
+/// Expand a leading `~` or `$HOME` against `home`. Leaves other paths untouched.
+fn expand_home(path: &str, home: &str) -> String {
+    let home = home.trim_end_matches('/');
+    if let Some(rest) = path.strip_prefix("~/") {
+        format!("{}/{}", home, rest)
+    } else if path == "~" {
+        home.to_string()
+    } else if let Some(rest) = path.strip_prefix("$HOME/") {
+        format!("{}/{}", home, rest)
+    } else if path == "$HOME" {
+        home.to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+/// Normalise for comparison: expand home, strip a trailing slash, lowercase
+/// (macOS default volumes are case-insensitive — matches `is_dangerous_command`).
+fn norm(path: &str, home: &str) -> String {
+    let expanded = expand_home(path, home);
+    let trimmed = expanded.trim_end_matches('/');
+    // Don't collapse root "/" (or "///") into an empty string.
+    if trimmed.is_empty() && expanded.starts_with('/') {
+        return "/".to_string();
+    }
+    trimmed.to_lowercase()
+}
+
+/// True if `child` is `ancestor` or a descendant of it (both pre-normalised).
+fn is_within(child: &str, ancestor: &str) -> bool {
+    child == ancestor || child.starts_with(&format!("{}/", ancestor))
+}
+
+/// Does this path contain a glob metacharacter in a *path segment*? (We only
+/// care about `*`, `?`, `[` — the unbounded-expansion forms.)
+fn has_glob(path: &str) -> bool {
+    path.contains('*') || path.contains('?') || path.contains('[')
+}
+
+/// Tokenise a single shell command into words, honouring backslash-escaped
+/// spaces (`Application\ Support`) and single/double quotes. This is a pragmatic
+/// tokenizer for *classification only*, not a full shell parser; it deliberately
+/// errs toward keeping a path together so we don't under-detect a protected
+/// target. Documented approximation — consistent with the policy.
+fn tokenize(cmd: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut cur = String::new();
+    let mut chars = cmd.chars().peekable();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut started = false;
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' if !in_single => {
+                if let Some(&next) = chars.peek() {
+                    cur.push(next);
+                    started = true;
+                    chars.next();
+                }
+            }
+            '\'' if !in_double => {
+                in_single = !in_single;
+                started = true;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                started = true;
+            }
+            c if c.is_whitespace() && !in_single && !in_double => {
+                if started {
+                    tokens.push(std::mem::take(&mut cur));
+                    started = false;
+                }
+            }
+            c => {
+                cur.push(c);
+                started = true;
+            }
+        }
+    }
+    if started {
+        tokens.push(cur);
+    }
+    tokens
+}
+
+/// Split a compound command on `;`, `&&`, `||`, `|` into its constituent simple
+/// commands so a sequence (`rm a; rm b`) is classified per-part. Crude but
+/// sufficient: we only need the leaders and path operands of each part.
+fn split_commands(cmd: &str) -> Vec<String> {
+    cmd.split(|c| c == ';' || c == '\n')
+        .flat_map(|s| s.split("&&"))
+        .flat_map(|s| s.split("||"))
+        .flat_map(|s| s.split('|'))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// The leader of a simple command, with a leading `sudo` stripped.
+fn leader_and_args(part: &str) -> (String, Vec<String>) {
+    let toks = tokenize(part);
+    let mut idx = 0;
+    if toks.get(0).map(|s| s.as_str()) == Some("sudo") {
+        idx = 1;
+        // skip sudo flags like -S, -n
+        while toks.get(idx).map(|s| s.starts_with('-')).unwrap_or(false) {
+            idx += 1;
+        }
+    }
+    let leader = toks.get(idx).cloned().unwrap_or_default();
+    let args = toks.get(idx + 1..).map(|s| s.to_vec()).unwrap_or_default();
+    (leader, args)
+}
+
+/// Path operands of a command (non-flag tokens after the leader).
+fn path_operands(args: &[String]) -> Vec<String> {
+    args.iter()
+        .filter(|a| !a.starts_with('-'))
+        .cloned()
+        .collect()
+}
+
+/// Hard-deny floor: machine-ending or identity-destroying actions, refused even
+/// with inspection and reaffirmation. Returns the refusal reason.
+pub fn hard_denied(cmd: &str, home: &str) -> Option<String> {
+    for part in split_commands(cmd) {
+        let (leader, args) = leader_and_args(&part);
+        let operands = path_operands(&args);
+
+        if leader == "rm" {
+            for op in &operands {
+                let n = norm(op, home);
+                // root / system / whole-Users wipes
+                if n == "/" || n == "/system" || n.starts_with("/system/")
+                    || n == "/users" || n == "/usr" || n.starts_with("/usr/")
+                {
+                    return Some(format!(
+                        "Refused: `{}` would damage the operating system itself. \
+                         This is a hard limit — Noah will not run it even if asked. \
+                         If the goal is free space, target user caches and large \
+                         files instead.",
+                        op
+                    ));
+                }
+                // auth / identity stores
+                let home_l = home.trim_end_matches('/').to_lowercase();
+                if n.starts_with(&format!("{}/library/keychains", home_l))
+                    || n.contains("/com.apple.tcc")
+                    || n.contains("com.apple.security")
+                {
+                    return Some(
+                        "Refused: this targets your Keychain / security identity. \
+                         Deleting it would lock you out of saved passwords and app \
+                         logins, irrecoverably. This is a hard limit."
+                            .to_string(),
+                    );
+                }
+            }
+        }
+
+        // secure-erase of a disk
+        if leader == "diskutil" {
+            let joined = args.join(" ").to_lowercase();
+            if joined.contains("erasedisk") || joined.contains("erasevolume")
+                || joined.contains("securerase") || joined.contains("zerodisk")
+            {
+                return Some(
+                    "Refused: erasing a disk/volume is irreversible and outside \
+                     what storage cleanup should ever do. This is a hard limit."
+                        .to_string(),
+                );
+            }
+        }
+    }
+    None
+}
+
+/// Classify a command against the inspected-set and return the gate decision.
+///
+/// `inspected` holds normalised (expanded, lowercased, trailing-slash-stripped)
+/// paths recorded by prior read-class observations this session.
+pub fn gate_decision(cmd: &str, home: &str, inspected: &HashSet<String>) -> GateDecision {
+    if let Some(reason) = hard_denied(cmd, home) {
+        return GateDecision::HardDeny { reason };
+    }
+
+    for part in split_commands(cmd) {
+        let (leader, args) = leader_and_args(&part);
+        if leader != "rm" {
+            continue;
+        }
+        for op in path_operands(&args) {
+            let n = norm(&op, home);
+
+            // Regenerable (cache/log) → never gated.
+            if REGENERABLE_HINTS.iter().any(|h| n.contains(h)) {
+                continue;
+            }
+
+            // Which protected tree (if any) does this operand fall in?
+            let tree = PROTECTED_TREES.iter().find_map(|t| {
+                let tn = norm(t, home);
+                if is_within(&n, &tn) {
+                    Some(tn)
+                } else {
+                    None
+                }
+            });
+            let Some(tree) = tree else { continue };
+
+            // Wildcard sweep over a protected tree → never clears.
+            if has_glob(&op) {
+                return GateDecision::RejectWildcard {
+                    tree: tree.clone(),
+                    tip: format!(
+                        "Held back: `{}` is a wildcard delete over a protected \
+                         folder, which removes whatever happens to be inside \
+                         (including data you can't get back). Instead: inspect \
+                         the folder (e.g. `du -sh '{}'/*`), then delete the \
+                         specific subdirectories you've confirmed are safe — one \
+                         explicit path at a time.",
+                        op, tree
+                    ),
+                };
+            }
+
+            // Concrete path: cleared only if inspected within the tree.
+            let cleared = inspected.iter().any(|i| {
+                is_within(i, &tree) && is_within(&n, i)
+            });
+            if !cleared {
+                return GateDecision::RejectNeedsInspection {
+                    path: n.clone(),
+                    tip: format!(
+                        "Held back: `{}` is inside a protected folder and Noah \
+                         hasn't looked at it yet. Inspect it first (e.g. \
+                         `ls -la '{}'` or `du -sh '{}'`) and confirm what it is \
+                         and that it's safe to remove, then retry this exact \
+                         delete.",
+                        op, op, op
+                    ),
+                };
+            }
+        }
+    }
+
+    GateDecision::Allow
+}
+
+/// Paths that a command inspects, normalised, to fold into the session
+/// inspected-set. Empty unless the command is a read-class observation.
+pub fn inspected_paths(cmd: &str, home: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for part in split_commands(cmd) {
+        let (leader, args) = leader_and_args(&part);
+        if !INSPECT_LEADERS.contains(&leader.as_str()) {
+            continue;
+        }
+        for op in path_operands(&args) {
+            // Record the directory being listed. Strip a trailing `/*` or `/.`
+            // so `du -sh ~/Foo/*` records `~/Foo` (you saw its children).
+            let base = op
+                .trim_end_matches("/*")
+                .trim_end_matches("/.")
+                .trim_end_matches("/*/");
+            let n = norm(base, home);
+            if !n.is_empty() && n != "/" {
+                out.push(n);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HOME: &str = "/Users/fbob";
+
+    fn set(paths: &[&str]) -> HashSet<String> {
+        paths.iter().map(|p| norm(p, HOME)).collect()
+    }
+
+    // ── The incident commands: every one of these must be held back ──────
+
+    #[test]
+    fn incident_wildcard_app_support_rejected() {
+        let d = gate_decision("rm -rf ~/Library/Application\\ Support/*", HOME, &set(&[]));
+        assert!(matches!(d, GateDecision::RejectWildcard { .. }), "{:?}", d);
+    }
+
+    #[test]
+    fn incident_sudo_wildcard_app_support_rejected() {
+        let d = gate_decision("sudo rm -rf ~/Library/Application\\ Support/*", HOME, &set(&[]));
+        assert!(matches!(d, GateDecision::RejectWildcard { .. }), "{:?}", d);
+    }
+
+    #[test]
+    fn incident_wildcard_containers_rejected() {
+        let d = gate_decision("rm -rf ~/Library/Containers/*", HOME, &set(&[]));
+        assert!(matches!(d, GateDecision::RejectWildcard { .. }), "{:?}", d);
+    }
+
+    #[test]
+    fn incident_messages_container_rejected_uninspected() {
+        let d = gate_decision("rm -rf ~/Library/Containers/com.apple.MobileSMS", HOME, &set(&[]));
+        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
+    }
+
+    #[test]
+    fn incident_messages_attachments_wildcard_rejected() {
+        let d = gate_decision("rm -rf ~/Library/Messages/Attachments/*", HOME, &set(&[]));
+        assert!(matches!(d, GateDecision::RejectWildcard { .. }), "{:?}", d);
+    }
+
+    #[test]
+    fn incident_group_containers_wildcard_rejected() {
+        let d = gate_decision("rm -rf ~/Library/Group\\ Containers/*", HOME, &set(&[]));
+        assert!(matches!(d, GateDecision::RejectWildcard { .. }), "{:?}", d);
+    }
+
+    // ── The unroll bypass: specific deletes still need inspection ─────────
+
+    #[test]
+    fn unrolled_specific_app_delete_rejected_without_inspection() {
+        // The exact bypass from the trace: enumerate instead of wildcard.
+        let d = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &set(&[]));
+        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
+    }
+
+    #[test]
+    fn sequence_of_specific_deletes_rejected_at_first_uninspected() {
+        let d = gate_decision(
+            "rm -rf ~/Library/Application\\ Support/Adobe; rm -rf ~/Library/Application\\ Support/obs-studio",
+            HOME,
+            &set(&[]),
+        );
+        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
+    }
+
+    // ── "Be my guest": inspected → allowed ───────────────────────────────
+
+    #[test]
+    fn specific_app_delete_allowed_after_inspecting_it() {
+        let inspected = set(&["~/Library/Application Support/Adobe"]);
+        let d = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected);
+        assert_eq!(d, GateDecision::Allow);
+    }
+
+    #[test]
+    fn specific_app_delete_allowed_after_inspecting_parent_tree() {
+        // Listing the tree root clears its descendants (you saw the listing).
+        let inspected = set(&["~/Library/Application Support"]);
+        let d = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected);
+        assert_eq!(d, GateDecision::Allow);
+    }
+
+    #[test]
+    fn wildcard_never_clears_even_after_inspection() {
+        // Even having looked, the unbounded sweep stays rejected — enumerate.
+        let inspected = set(&["~/Library/Application Support"]);
+        let d = gate_decision("rm -rf ~/Library/Application\\ Support/*", HOME, &inspected);
+        assert!(matches!(d, GateDecision::RejectWildcard { .. }), "{:?}", d);
+    }
+
+    #[test]
+    fn inspecting_home_does_not_clear_protected_child() {
+        // `ls ~` is above the tree root → clears nothing inside it.
+        let inspected = set(&["~"]);
+        let d = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected);
+        assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
+    }
+
+    // ── Regenerable: caches/logs never gated ─────────────────────────────
+
+    #[test]
+    fn caches_wildcard_allowed() {
+        let d = gate_decision("rm -rf ~/Library/Caches/*", HOME, &set(&[]));
+        assert_eq!(d, GateDecision::Allow);
+    }
+
+    #[test]
+    fn app_support_cache_subdir_allowed() {
+        let d = gate_decision(
+            "rm -rf ~/Library/Application\\ Support/Foo/Caches/blobs",
+            HOME,
+            &set(&[]),
+        );
+        assert_eq!(d, GateDecision::Allow);
+    }
+
+    #[test]
+    fn logs_allowed() {
+        let d = gate_decision("rm -rf ~/Library/Logs/old", HOME, &set(&[]));
+        assert_eq!(d, GateDecision::Allow);
+    }
+
+    // ── Non-protected and non-delete: untouched ──────────────────────────
+
+    #[test]
+    fn delete_outside_protected_tree_allowed() {
+        let d = gate_decision("rm -rf ~/Downloads/installer.dmg", HOME, &set(&[]));
+        assert_eq!(d, GateDecision::Allow);
+    }
+
+    #[test]
+    fn non_rm_command_allowed() {
+        let d = gate_decision("du -sh ~/Library/Application\\ Support/*", HOME, &set(&[]));
+        assert_eq!(d, GateDecision::Allow);
+    }
+
+    // ── Hard-deny floor ──────────────────────────────────────────────────
+
+    #[test]
+    fn rm_root_hard_denied() {
+        let d = gate_decision("rm -rf /", HOME, &set(&[]));
+        assert!(matches!(d, GateDecision::HardDeny { .. }), "{:?}", d);
+    }
+
+    #[test]
+    fn rm_system_hard_denied() {
+        let d = gate_decision("sudo rm -rf /System", HOME, &set(&[]));
+        assert!(matches!(d, GateDecision::HardDeny { .. }), "{:?}", d);
+    }
+
+    #[test]
+    fn keychain_hard_denied_even_if_inspected() {
+        let inspected = set(&["~/Library/Keychains"]);
+        let d = gate_decision("rm -rf ~/Library/Keychains", HOME, &inspected);
+        assert!(matches!(d, GateDecision::HardDeny { .. }), "{:?}", d);
+    }
+
+    #[test]
+    fn diskutil_erase_hard_denied() {
+        let d = gate_decision("diskutil eraseDisk APFS Blank disk0", HOME, &set(&[]));
+        assert!(matches!(d, GateDecision::HardDeny { .. }), "{:?}", d);
+    }
+
+    // ── inspected_paths extraction ───────────────────────────────────────
+
+    #[test]
+    fn inspected_paths_records_du_target() {
+        let p = inspected_paths("du -sh ~/Library/Application\\ Support/Adobe", HOME);
+        assert_eq!(p, vec![norm("~/Library/Application Support/Adobe", HOME)]);
+    }
+
+    #[test]
+    fn inspected_paths_strips_trailing_wildcard() {
+        let p = inspected_paths("du -sh ~/Library/Application\\ Support/*", HOME);
+        assert_eq!(p, vec![norm("~/Library/Application Support", HOME)]);
+    }
+
+    #[test]
+    fn inspected_paths_handles_ls() {
+        let p = inspected_paths("ls -la ~/Library/Containers/com.apple.MobileSMS", HOME);
+        assert_eq!(p, vec![norm("~/Library/Containers/com.apple.MobileSMS", HOME)]);
+    }
+
+    #[test]
+    fn inspected_paths_empty_for_rm() {
+        assert!(inspected_paths("rm -rf ~/Library/Caches/*", HOME).is_empty());
+    }
+
+    // ── End-to-end: the careful path the harness is meant to produce ─────
+
+    #[test]
+    fn careful_flow_inspect_then_delete_succeeds() {
+        // 1. Blind delete is rejected.
+        let mut inspected: HashSet<String> = HashSet::new();
+        let d1 = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected);
+        assert!(matches!(d1, GateDecision::RejectNeedsInspection { .. }));
+
+        // 2. Model inspects (as the tip instructs).
+        for p in inspected_paths("du -sh ~/Library/Application\\ Support/Adobe", HOME) {
+            inspected.insert(p);
+        }
+
+        // 3. Retry now clears — be my guest.
+        let d2 = gate_decision("rm -rf ~/Library/Application\\ Support/Adobe", HOME, &inspected);
+        assert_eq!(d2, GateDecision::Allow);
+    }
+}

--- a/crates/noah-tools/src/safety.rs
+++ b/crates/noah-tools/src/safety.rs
@@ -101,6 +101,11 @@ const FIRMLINK_PREFIXES: &[&str] = &["/system/volumes/data"];
 pub enum GateDecision {
     /// Not a protected-tree delete (or it's regenerable). Proceed to normal flow.
     Allow,
+    /// The command deletes, but not in a form the harness can fully analyse
+    /// (a pipe, `find`/`xargs`, command substitution, a variable, `eval`, or a
+    /// relative path). **Fail-closed**: re-express as a plain `rm`/`unlink` on
+    /// an absolute or `~`-rooted path. The harness only runs deletions it can read.
+    RejectNonCanonical { tip: String },
     /// Concrete delete of a specific path inside a protected tree that hasn't
     /// been inspected. Carries a tip instructing the model to inspect first.
     RejectNeedsInspection { path: String, tip: String },
@@ -119,6 +124,7 @@ impl GateDecision {
     pub fn classification(&self) -> &'static str {
         match self {
             GateDecision::Allow => "allow",
+            GateDecision::RejectNonCanonical { .. } => "non_canonical",
             GateDecision::RejectNeedsInspection { .. } => "inspect_then_delete",
             GateDecision::RejectSweep { .. } => "reject_sweep",
             GateDecision::HardDeny { .. } => "hard_deny",
@@ -128,6 +134,7 @@ impl GateDecision {
     pub fn message(&self) -> String {
         match self {
             GateDecision::Allow => String::new(),
+            GateDecision::RejectNonCanonical { tip } => tip.clone(),
             GateDecision::RejectNeedsInspection { tip, .. } => tip.clone(),
             GateDecision::RejectSweep { tip, .. } => tip.clone(),
             GateDecision::HardDeny { reason } => reason.clone(),
@@ -430,6 +437,136 @@ pub fn hard_denied(cmd: &str, home: &str) -> Option<String> {
     None
 }
 
+// ── Canonical-form allowlist (fail-closed) ───────────────────────────────
+
+/// True if the command performs (or could launder) a deletion at all. When this
+/// is false we don't care about the command. When true, it must be canonical.
+fn mentions_deletion(cmd: &str) -> bool {
+    let xargs_rm = has_xargs_rm(cmd);
+    for part in split_commands(cmd) {
+        let (leader, args) = leader_and_args(&part);
+        match leader.as_str() {
+            "rm" | "unlink" | "srm" | "shred" | "rmdir" => return true,
+            "find" if find_args_destructive(&args) || xargs_rm => return true,
+            "xargs" if xargs_rm => return true,
+            "eval" => return true,
+            // pipe-to-shell laundering (`… | sh`)
+            "sh" | "bash" | "zsh" if has_pipe(cmd) => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
+/// A `|` pipe that is not part of `||`.
+fn has_pipe(cmd: &str) -> bool {
+    cmd.replace("||", "\u{0}\u{0}").contains('|')
+}
+
+/// Is this token an acceptable `rm` flag? Short flags only, from a safe set;
+/// long flags (`--no-preserve-root`) and unknown flags are rejected.
+fn valid_rm_flag(a: &str) -> bool {
+    a.len() > 1
+        && a.starts_with('-')
+        && !a.starts_with("--")
+        && a[1..].chars().all(|c| "rRfidvPW".contains(c))
+}
+
+/// An operand the harness can resolve to a concrete location: absolute, or
+/// `~`/`$HOME`-rooted. Globs are allowed (the base is still concrete). Relative
+/// paths, other variables, and command substitution are not.
+fn canonical_operand(op: &str) -> bool {
+    if op.contains("$(") || op.contains('`') {
+        return false;
+    }
+    if op.starts_with('/') || op == "~" || op.starts_with("~/") {
+        return true;
+    }
+    if op == "$HOME" || op.starts_with("$HOME/") {
+        return true;
+    }
+    if op.contains('$') {
+        return false; // some other variable
+    }
+    false // relative
+}
+
+fn tip_noncanonical(what: &str) -> String {
+    format!(
+        "Held back: this delete uses {} — a form Noah can't fully read before \
+         running, so it won't run it. Re-express it so the target is statically \
+         visible: a plain `rm -rf <path>` / `unlink <path>`, or a `find <path> … \
+         -delete` / `-exec rm` whose root is an absolute or `~`-rooted path — no \
+         pipes, no `xargs`, no `$(...)`, no variables, no relative paths. Inspect \
+         first if it's inside a protected folder.",
+        what
+    )
+}
+
+fn operand_why(op: &str) -> String {
+    let why = if op.contains("$(") || op.contains('`') {
+        "command substitution"
+    } else if op.contains('$') {
+        "a shell variable"
+    } else {
+        "a relative path"
+    };
+    format!("{} (`{}`)", why, op)
+}
+
+/// Why (if at all) a deletion command is not in canonical form. Permits
+/// `rm`/`unlink` on literal paths, and a **non-piped** `find <literal-root> …
+/// -delete/-exec rm` (its root is statically checkable; predicates only narrow
+/// what's removed). Rejects pipes, `xargs`, substitution, variables, relative
+/// paths, `eval`, and the secure/dir deleters.
+fn canonical_violation(cmd: &str) -> Option<String> {
+    if has_pipe(cmd) {
+        return Some(tip_noncanonical("a pipe"));
+    }
+    if cmd.contains("$(") || cmd.contains('`') {
+        return Some(tip_noncanonical("command substitution `$(...)`"));
+    }
+    for part in split_commands(cmd) {
+        let (leader, args) = leader_and_args(&part);
+        match leader.as_str() {
+            "rm" | "unlink" => {
+                for a in &args {
+                    if a.starts_with('-') && (leader == "unlink" || !valid_rm_flag(a)) {
+                        return Some(tip_noncanonical(&format!("the flag `{}`", a)));
+                    }
+                }
+                for op in path_operands(&args) {
+                    if !canonical_operand(&op) {
+                        return Some(tip_noncanonical(&operand_why(&op)));
+                    }
+                }
+            }
+            "find" if find_args_destructive(&args) => {
+                let roots = find_roots(&args);
+                if roots.is_empty() {
+                    return Some(tip_noncanonical(
+                        "a `find` with no explicit path (it would default to the current directory)",
+                    ));
+                }
+                for r in &roots {
+                    if !canonical_operand(r) {
+                        return Some(tip_noncanonical(&format!(
+                            "a `find` root that isn't an absolute/`~`-rooted path ({})",
+                            operand_why(r)
+                        )));
+                    }
+                }
+            }
+            // Secure/dir deleters and indirection: funnel to the plain forms.
+            "srm" | "shred" | "rmdir" | "xargs" | "eval" => {
+                return Some(tip_noncanonical(&format!("`{}`", leader)));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 // ── The gate ─────────────────────────────────────────────────────────────
 
 /// Classify a command against the inspected-set and return the gate decision.
@@ -438,6 +575,14 @@ pub fn hard_denied(cmd: &str, home: &str) -> Option<String> {
 pub fn gate_decision(cmd: &str, home: &str, inspected: &HashSet<String>) -> GateDecision {
     if let Some(reason) = hard_denied(cmd, home) {
         return GateDecision::HardDeny { reason };
+    }
+
+    // Fail-closed allowlist: a command that deletes must do so in a form the
+    // harness can fully analyse, or it doesn't run.
+    if mentions_deletion(cmd) {
+        if let Some(tip) = canonical_violation(cmd) {
+            return GateDecision::RejectNonCanonical { tip };
+        }
     }
 
     for op in delete_targets_raw(cmd) {
@@ -649,10 +794,12 @@ mod tests {
         ));
     }
 
-    // ── find / xargs / unlink vectors ────────────────────────────────────
+    // ── Visible-root find: permitted, then gated on the root ─────────────
 
     #[test]
-    fn find_delete_in_protected_tree_rejected() {
+    fn find_delete_on_tree_root_is_sweep() {
+        // Non-piped find with a checkable root → flows to the tree gate; root
+        // IS the protected tree → sweep.
         let d = gate_decision(
             "find ~/Library/Application\\ Support -maxdepth 1 -type d -delete",
             HOME,
@@ -661,45 +808,127 @@ mod tests {
         assert!(matches!(d, GateDecision::RejectSweep { .. }), "{:?}", d);
     }
     #[test]
-    fn find_exec_rm_in_protected_tree_rejected() {
+    fn find_exec_rm_on_specific_subdir_is_inspect_gated() {
         let d = gate_decision(
             "find ~/Library/Containers/com.apple.MobileSMS -exec rm -rf {} +",
             HOME,
             &empty(),
         );
-        // Concrete subdir of Containers → inspect-gate.
         assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
     }
     #[test]
-    fn find_pipe_xargs_rm_rejected() {
+    fn find_delete_in_unprotected_age_filtered_allowed() {
+        // The bundled-recipe shape: age-filtered cleanup of a non-protected dir.
+        assert_eq!(
+            gate_decision("find ~/Library/Logs -mtime +7 -delete", HOME, &empty()),
+            GateDecision::Allow
+        );
+        assert_eq!(
+            gate_decision(
+                "find /Applications -maxdepth 1 -name 'Install macOS*' -mtime +14 -exec rm -rf {} +",
+                HOME,
+                &empty()
+            ),
+            GateDecision::Allow
+        );
+    }
+    #[test]
+    fn find_pipe_xargs_rm_is_non_canonical() {
+        // The pipe is the disqualifier — a grep/sed could diverge the set.
         let d = gate_decision(
             "find ~/Library/Application\\ Support -name '*' | xargs rm -rf",
             HOME,
             &empty(),
         );
-        assert!(matches!(d, GateDecision::RejectSweep { .. }), "{:?}", d);
+        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
     }
     #[test]
-    fn unlink_in_protected_tree_gated() {
+    fn find_with_relative_root_is_non_canonical() {
+        for cmd in ["find . -name '*.tmp' -delete", "find Library -delete"] {
+            assert!(
+                matches!(gate_decision(cmd, HOME, &empty()), GateDecision::RejectNonCanonical { .. }),
+                "should reject relative find root: {cmd}"
+            );
+        }
+    }
+    #[test]
+    fn find_with_no_explicit_root_is_non_canonical() {
+        let d = gate_decision("find -name '*.log' -delete", HOME, &empty());
+        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+    }
+    #[test]
+    fn rmdir_shred_srm_are_non_canonical() {
+        for cmd in [
+            "rmdir ~/Library/Application\\ Support/Adobe",
+            "shred -u ~/Documents/x",
+            "srm -rf ~/Documents/x",
+        ] {
+            assert!(
+                matches!(gate_decision(cmd, HOME, &empty()), GateDecision::RejectNonCanonical { .. }),
+                "should be non-canonical: {cmd}"
+            );
+        }
+    }
+    #[test]
+    fn unlink_canonical_then_gated() {
+        // unlink IS a canonical leader; the path is then gated by the tree logic.
         let d = gate_decision("unlink ~/Documents/taxes.pdf", HOME, &empty());
         assert!(matches!(d, GateDecision::RejectNeedsInspection { .. }), "{:?}", d);
     }
     #[test]
     fn nondestructive_find_is_not_a_delete() {
-        let d = gate_decision(
-            "find ~/Library/Application\\ Support -name '*.log'",
-            HOME,
-            &empty(),
+        assert_eq!(
+            gate_decision("find ~/Library/Application\\ Support -name '*.log'", HOME, &empty()),
+            GateDecision::Allow
         );
-        assert_eq!(d, GateDecision::Allow);
     }
     #[test]
     fn destructive_find_does_not_count_as_inspection() {
-        assert!(inspected_paths(
-            "find ~/Library/Application\\ Support -delete",
-            HOME
-        )
-        .is_empty());
+        assert!(inspected_paths("find ~/Library/Application\\ Support -delete", HOME).is_empty());
+    }
+
+    // ── Fail-closed: indirection & relative paths the harness can't read ──
+
+    #[test]
+    fn relative_path_delete_is_non_canonical() {
+        // The cd-then-relative bypass.
+        let d = gate_decision("cd ~ && rm -rf Library/Application\\ Support/Adobe", HOME, &empty());
+        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+    }
+    #[test]
+    fn command_substitution_delete_is_non_canonical() {
+        let d = gate_decision("rm -rf $(cat ~/to-delete.txt)", HOME, &empty());
+        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+    }
+    #[test]
+    fn variable_operand_is_non_canonical() {
+        let d = gate_decision("rm -rf $TARGET/cache", HOME, &empty());
+        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+    }
+    #[test]
+    fn pipe_in_delete_is_non_canonical() {
+        let d = gate_decision("ls ~/Library | rm -rf ~/Library/Caches", HOME, &empty());
+        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+    }
+    #[test]
+    fn eval_is_non_canonical() {
+        let d = gate_decision("eval \"rm -rf ~/Library/Application Support\"", HOME, &empty());
+        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+    }
+    #[test]
+    fn pipe_to_shell_is_non_canonical() {
+        let d = gate_decision("echo cm0gLXJmIH4v | base64 -d | sh", HOME, &empty());
+        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+    }
+    #[test]
+    fn no_preserve_root_flag_is_non_canonical() {
+        let d = gate_decision("rm -rf --no-preserve-root /tmp/x", HOME, &empty());
+        assert!(matches!(d, GateDecision::RejectNonCanonical { .. }), "{:?}", d);
+    }
+    #[test]
+    fn canonical_absolute_rm_outside_protected_allowed() {
+        // The blessed form, in a safe location → just runs.
+        assert_eq!(gate_decision("rm -rf /tmp/build-cache", HOME, &empty()), GateDecision::Allow);
     }
 
     // ── New protected trees ──────────────────────────────────────────────


### PR DESCRIPTION
## Why

A real trialing-then-paying user asked Noah to "push storage to Google Drive … target under 410 GB." Over ~44 steps Noah held the quota and freed 77 GB — the agentic, goal-driven cleanup that is the product's moat. But the same loop, gated only by a 2-second click-through approval showing Noah's own one-line reason, also ran `sudo rm -rf ~/Library/Application Support/*`, deleted iMessage data, removed the Time Machine safety net, and **silently swapped the user's chosen method (move/preserve) for delete** — never touching Google Drive. We couldn't even tell which deletes succeeded, because telemetry logged the *proposed* shell command, not the approval decision or result.

Our only code-enforced guard was "command contains `rm`/`sudo` → ask." Everything else protecting user data was advisory playbook prose: holey, and possibly not even loaded for that phrasing.

## What this does

Moves the redline out of playbook prose and **into the harness** (it needs session state, so it lives in the orchestrator — mirroring Claude Code's read-before-edit). Four layers, applied to `shell_run`:

1. **Fail-closed canonical allowlist.** A command that deletes must express its target root *statically*, or it doesn't run. Permitted: `rm`/`unlink` on literal absolute/`~`-rooted paths, and non-piped `find <literal-root> … -delete/-exec rm` (root is checkable; `-mtime`/`-name` only narrow within it, so age/size-filtered cleanup survives). Rejected: pipes, `xargs`, `$(…)`/backticks, `eval`, variables other than `$HOME`, relative paths (closes `cd ~ && rm Library/…`), rootless `find`, `srm`/`shred`/`rmdir`, long flags like `--no-preserve-root`.
2. **Protected-tree inspect-before-delete.** A concrete delete inside a protected tree is held back until that path was inspected (`ls`/`du`) this session — the read-before-edit precedent, a structural check (did the model *look*?), not semantic. Cleared, then "be my guest."
3. **Sweep rejection.** A wildcard, the tree root itself, or an ancestor of it is rejected outright (never inspection-cleared) — the model must enumerate specific subpaths.
4. **Hard-deny floor.** `rm -rf /`, home/`/System`/`/Users` wipes, Keychain/TCC/security stores, `diskutil erase` — refused even with inspection + reaffirmation.

**Telemetry (closes the blind spot):** emits `tool_approved` (previously only `tool_denied`) and `safety_gate` events from the execution layer.

## Quality of the approximation — verified, not guessed

The whole value is that the approximation is good, so the protected-tree list and normalization were stress-tested against authoritative sources:

- **Firmlink bypass** — confirmed on a live machine that `~/Library` and `/System/Volumes/Data/Users/<u>/Library` are the *same inode*; the real incident trace used the long form. `norm()` strips the firmlink prefix.
- **Ancestor / whole-tree sweeps** — `rm -rf ~/Library` (ancestor of every tree) and the tree root itself were missed by the first cut; now rejected.
- **Protected trees** aligned to Apple's TCC set (Desktop, Documents, Downloads, Mail, Messages, Safari, Contacts, Calendars, Photos) + credential stores (`~/.ssh`, `~/.gnupg`, `~/.aws`, …).
- **Regenerable hint** scoped to app-state trees only, so `~/Documents/cache/` (the user's own folder) isn't wrongly exempt.

**Threat model (stated, not hidden):** defends against our own over-eager model reaching for sweeping constructs — the incident — not an adversarial model laundering `rm` through base64. The latter is out of scope and documented.

Playbooks are demoted to advice; `disk-space-recovery.md` now reinforces offload (copy → verify → delete) over straight-delete.

## Tests

52 unit tests in `crates/noah-tools/src/safety.rs`, built from the exact incident commands + every bypass class (firmlink, ancestor, find/xargs/unlink/eval/substitution/relative-path, over-broad-hint). Full workspace `cargo test` green; `noah-tools` builds clean.

Full rationale and the decision record: `apps/desktop/src-tauri/docs/safety-policy.md`.

## Follow-ups (not in this PR)

- Forward the `action_event` telemetry to noah-consumer `/events/action`.
- Bind the touched-paths manifest into the `safety::journal` so deletes are undoable / auditable.
