### PR TITLE
paywall(desktop): scan-reveal A/B placement primitive

### DIFF
--- a/apps/desktop/src/components/OnboardingFlow.test.tsx
+++ b/apps/desktop/src/components/OnboardingFlow.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import type { Entitlement } from "../lib/tauri-commands";
+import { useConsumerStore } from "../stores/consumerStore";
+import { OnboardingFlow } from "./OnboardingFlow";
+
+function setArm(placement: "launch" | "after_fix", extra: Partial<Entitlement> = {}) {
+  useConsumerStore.setState({
+    entitlement: {
+      plan: null, status: "none", trial_started_at: null, trial_ends_at: null,
+      period_start: null, period_end: null, usage_used: 0, usage_limit: 10,
+      fix_count_total: 0, paywall_placement: placement, ...extra,
+    },
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  useConsumerStore.setState({ entitlement: null, subscribeModal: null });
+});
+
+describe("OnboardingFlow", () => {
+  it("walks welcome → pick → scan → reveal (problem-led)", async () => {
+    setArm("after_fix"); // no paywall in the way for the navigation check
+    render(<OnboardingFlow onComplete={() => {}} scanDurationMs={0} />);
+
+    expect(screen.getByTestId("ob-welcome")).toBeTruthy();
+    fireEvent.click(screen.getByText("Get started"));
+    expect(screen.getByTestId("ob-pick")).toBeTruthy();
+    expect(screen.getByText("What's bugging you?")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Look into it →"));
+    expect(screen.getByTestId("ob-scan")).toBeTruthy();
+
+    await waitFor(() => expect(screen.getByTestId("ob-reveal")).toBeTruthy());
+    // diagnosis, not a junk list
+    expect(screen.getByText("Tied up by Chrome + 47 tabs")).toBeTruthy();
+  });
+
+  it("launch arm: surfaces the scan_reveal paywall at the reveal", async () => {
+    setArm("launch");
+    render(<OnboardingFlow onComplete={() => {}} scanDurationMs={0} />);
+    fireEvent.click(screen.getByText("Get started"));
+    fireEvent.click(screen.getByText("Look into it →"));
+
+    await waitFor(() =>
+      expect(useConsumerStore.getState().subscribeModal).toEqual({ variant: "scan_reveal" }),
+    );
+  });
+
+  it("after_fix arm: no paywall during onboarding", async () => {
+    setArm("after_fix");
+    render(<OnboardingFlow onComplete={() => {}} scanDurationMs={0} />);
+    fireEvent.click(screen.getByText("Get started"));
+    fireEvent.click(screen.getByText("Look into it →"));
+    await waitFor(() => expect(screen.getByTestId("ob-reveal")).toBeTruthy());
+    expect(useConsumerStore.getState().subscribeModal).toBeNull();
+  });
+
+  it("honors the ad's pre-selected problem (storage)", async () => {
+    setArm("after_fix");
+    render(<OnboardingFlow onComplete={() => {}} initialProblem="storage" scanDurationMs={0} />);
+    fireEvent.click(screen.getByText("Get started"));
+    fireEvent.click(screen.getByText("Look into it →"));
+    // storage-specific diagnosis card (headline text is split across spans)
+    await waitFor(() => expect(screen.getByText("Reclaimable now")).toBeTruthy());
+  });
+
+  it("the reveal CTA completes onboarding", async () => {
+    setArm("after_fix");
+    const onComplete = vi.fn();
+    render(<OnboardingFlow onComplete={onComplete} scanDurationMs={0} />);
+    fireEvent.click(screen.getByText("Get started"));
+    fireEvent.click(screen.getByText("Look into it →"));
+    await waitFor(() => expect(screen.getByTestId("ob-reveal")).toBeTruthy());
+    fireEvent.click(screen.getByText("Fix it →"));
+    expect(onComplete).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/components/OnboardingFlow.tsx
+++ b/apps/desktop/src/components/OnboardingFlow.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from "react";
+import { useConsumerStore } from "../stores/consumerStore";
+import { useScanRevealPaywall } from "../stores/useScanRevealPaywall";
+
+/**
+ * Noah onboarding — problem-led, proof-first. Welcome → "what's wrong?" →
+ * a real (here: simulated) scan → a *diagnosis* (not a junk list) → and at the
+ * reveal it mounts `useScanRevealPaywall`, which surfaces the card-on-file trial
+ * paywall for launch-arm users. Design spec + rationale:
+ * noah-consumer/designs/onboarding/SPEC.md.
+ *
+ * The paywall itself is the app-level <SubscribeModal>, opened via the store by
+ * the hook — so this component only drives the steps and the signals. Findings
+ * and scan duration are injectable so the real diagnostics (and tests) plug in.
+ */
+type Step = "welcome" | "pick" | "scan" | "reveal";
+type Tone = "bad" | "warn" | "ok";
+
+export interface Finding {
+  tone: Tone;
+  big: string;
+  label: string;
+  detail: string;
+}
+
+export interface OnboardingFlowProps {
+  /** Called when the user finishes / skips onboarding into the app. */
+  onComplete: () => void;
+  /** Pre-selected problem (e.g. passed through from the ad). Defaults to "slow". */
+  initialProblem?: string;
+  /** Scan dwell before the reveal. Override (e.g. 0) in tests. */
+  scanDurationMs?: number;
+  /** Diagnosis cards per problem. Defaults to the built-in set. */
+  findingsByProblem?: Record<string, Finding[]>;
+}
+
+const PROBLEMS: { id: string; emoji: string; title: string; sub: string }[] = [
+  { id: "slow", emoji: "🐢", title: "It's slow", sub: "lags, beachballs, fans spinning" },
+  { id: "storage", emoji: "💾", title: "It's full", sub: "out of storage, can't update" },
+  { id: "wifi", emoji: "📶", title: "Won't connect", sub: "Wi-Fi drops, sites won't load" },
+  { id: "security", emoji: "🔒", title: "Feels unsafe", sub: "pop-ups, privacy, malware" },
+  { id: "backup", emoji: "🛟", title: "Not backed up", sub: "scared of losing things" },
+  { id: "other", emoji: "💬", title: "Something else", sub: "just ask — I'll figure it out" },
+];
+
+// Lead plain, one credible detail for depth (design call #3).
+const DEFAULT_FINDINGS: Record<string, Finding[]> = {
+  slow: [
+    { tone: "bad", big: "9.1 GB", label: "Tied up by Chrome + 47 tabs", detail: "starving the rest of your Mac" },
+    { tone: "warn", big: "1 core", label: "Pinned by a stuck process", detail: "a backup helper looping in the background" },
+    { tone: "warn", big: "12 apps", label: "Launch at login", detail: "loading on startup, mostly unused" },
+    { tone: "ok", big: "23 GB", label: "Junk I can also clear", detail: "caches, logs, old installers" },
+  ],
+  storage: [
+    { tone: "bad", big: "31 GB", label: "Reclaimable now", detail: "caches, old installers, trash" },
+    { tone: "warn", big: "18 GB", label: "Duplicate downloads", detail: "same files, many copies" },
+    { tone: "warn", big: "4.2 GB", label: "Leftover from deleted apps", detail: "support files no app uses" },
+    { tone: "ok", big: "On", label: "iCloud could offload more", detail: "I can set that up too" },
+  ],
+};
+
+const TONE: Record<Tone, { bg: string; fg: string; mark: string }> = {
+  bad: { bg: "rgba(239,68,68,0.12)", fg: "#ef4444", mark: "!" },
+  warn: { bg: "rgba(245,158,11,0.14)", fg: "#d97706", mark: "!" },
+  ok: { bg: "rgba(16,185,129,0.14)", fg: "#0f9d6b", mark: "✓" },
+};
+
+const btn =
+  "inline-flex items-center justify-center gap-2 rounded-2xl px-7 py-3.5 text-[15px] font-semibold text-white cursor-pointer";
+
+export function OnboardingFlow({
+  onComplete,
+  initialProblem,
+  scanDurationMs = 2600,
+  findingsByProblem = DEFAULT_FINDINGS,
+}: OnboardingFlowProps) {
+  const [step, setStep] = useState<Step>("welcome");
+  const [problem, setProblem] = useState(initialProblem ?? "slow");
+  const fixCount = useConsumerStore((s) => s.entitlement?.fix_count_total ?? 0);
+
+  // The integration: once the reveal is on screen, surface the launch-arm
+  // paywall (the hook is a one-shot no-op for the after-fix arm / trialing users).
+  useScanRevealPaywall({ scanRevealed: step === "reveal", firstFixReached: fixCount > 0 });
+
+  useEffect(() => {
+    if (step !== "scan") return;
+    const id = setTimeout(() => setStep("reveal"), scanDurationMs);
+    return () => clearTimeout(id);
+  }, [step, scanDurationMs]);
+
+  const findings = findingsByProblem[problem] ?? findingsByProblem.slow ?? [];
+
+  return (
+    <div className="fixed inset-0 z-40 flex flex-col items-center justify-center px-8 text-center bg-bg-primary"
+         style={{ background: "radial-gradient(820px 480px at 50% 30%, var(--aurora-soft), transparent 64%)" }}>
+      {step === "welcome" && (
+        <div data-testid="ob-welcome">
+          <Orb />
+          <h1 className="text-[32px] font-bold tracking-tight leading-tight text-text-primary">
+            Something wrong with your Mac?<br />
+            <span style={{ background: "var(--aurora)", WebkitBackgroundClip: "text", backgroundClip: "text", color: "transparent" }}>Just tell Noah.</span>
+          </h1>
+          <p className="text-[15px] text-text-secondary mt-3.5 max-w-[460px] mx-auto leading-relaxed">
+            Slow, full, won't connect, acting strange — Noah figures out what's actually wrong and fixes it with you.
+          </p>
+          <button className={btn + " mt-7"} style={{ background: "var(--aurora)" }} onClick={() => setStep("pick")}>Get started</button>
+        </div>
+      )}
+
+      {step === "pick" && (
+        <div data-testid="ob-pick" className="w-full max-w-[600px]">
+          <Eyebrow>Let's start with you</Eyebrow>
+          <h1 className="text-[28px] font-bold tracking-tight text-text-primary">What's bugging you?</h1>
+          <p className="text-[14px] text-text-secondary mt-2 mb-5">Pick what's wrong — Noah handles all of it. Not sure? That's fine too.</p>
+          <div className="grid grid-cols-2 gap-2.5 text-left">
+            {PROBLEMS.map((p) => {
+              const sel = problem === p.id;
+              return (
+                <button key={p.id} onClick={() => setProblem(p.id)}
+                  className="flex items-center gap-3 p-3.5 rounded-2xl bg-bg-secondary border cursor-pointer"
+                  style={{ borderColor: sel ? "transparent" : "var(--color-border-primary)", boxShadow: sel ? "0 0 0 2px var(--color-text-primary) inset" : "none" }}>
+                  <span className="text-2xl">{p.emoji}</span>
+                  <span><span className="block text-[15px] font-semibold text-text-primary">{p.title}</span>
+                    <span className="block text-[12.5px] text-text-muted">{p.sub}</span></span>
+                </button>
+              );
+            })}
+          </div>
+          <p className="text-[12.5px] text-text-muted mt-5">Noah looks read-only first, on your Mac. Nothing is deleted or sent anywhere without your OK.</p>
+          <button className={btn + " mt-6"} style={{ background: "var(--aurora)" }} onClick={() => setStep("scan")}>Look into it →</button>
+        </div>
+      )}
+
+      {step === "scan" && (
+        <div data-testid="ob-scan">
+          <Orb />
+          <h1 className="text-[30px] font-bold tracking-tight text-text-primary">Finding out what's going on…</h1>
+          <p className="text-[15px] text-text-secondary mt-3.5 max-w-[440px] mx-auto leading-relaxed">
+            Reading your real system — what's running, what's stuck, what's piling up. No guesses.
+          </p>
+        </div>
+      )}
+
+      {step === "reveal" && (
+        <div data-testid="ob-reveal" className="w-full max-w-[640px]">
+          <Eyebrow>Here's what's really going on</Eyebrow>
+          <h1 className="text-[28px] font-bold tracking-tight text-text-primary">
+            Why <span style={{ background: "var(--aurora)", WebkitBackgroundClip: "text", backgroundClip: "text", color: "transparent" }}>your</span> Mac {problem === "storage" ? "is full" : "feels slow"}.
+          </h1>
+          <div className="grid grid-cols-2 gap-3 mt-6 text-left">
+            {findings.map((f, i) => (
+              <div key={i} className="flex gap-3 items-start p-4 rounded-2xl bg-bg-secondary border border-border-primary">
+                <span className="w-8 h-8 flex-none grid place-items-center rounded-lg text-base font-bold"
+                      style={{ background: TONE[f.tone].bg, color: TONE[f.tone].fg }}>{TONE[f.tone].mark}</span>
+                <span>
+                  <span className="block text-[19px] font-bold leading-none text-text-primary">{f.big}</span>
+                  <span className="block text-[13px] font-semibold mt-1 text-text-primary">{f.label}</span>
+                  <span className="block text-[12px] text-text-muted mt-0.5">{f.detail}</span>
+                </span>
+              </div>
+            ))}
+          </div>
+          <p className="text-[14.5px] text-text-secondary mt-5">It's more than junk — <b className="text-text-primary">I can fix the real cause now.</b></p>
+          {/* Launch arm: the paywall appears over this (via the hook). For the
+              after-fix arm, this button starts the first free fix. */}
+          <button className={btn + " mt-5"} style={{ background: "var(--aurora)" }} onClick={onComplete}>Fix it →</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return <div className="text-[12px] tracking-[0.14em] uppercase font-bold mb-3.5" style={{ color: "var(--text-eyebrow, var(--color-text-muted))" }}>{children}</div>;
+}
+
+function Orb() {
+  return (
+    <div className="w-[72px] h-[72px] rounded-full grid place-items-center mx-auto mb-7"
+         style={{ background: "var(--aurora)", boxShadow: "var(--aurora-glow)" }}>
+      <svg viewBox="0 0 24 24" width="36" height="36" fill="none" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M18.4 5.6l-2.1 2.1M7.7 16.3l-2.1 2.1" />
+        <circle cx="12" cy="12" r="3.2" fill="#fff" stroke="none" />
+      </svg>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/SubscribeModal.tsx
+++ b/apps/desktop/src/components/SubscribeModal.tsx
@@ -6,8 +6,11 @@ import { useConsumerStore } from "../stores/consumerStore";
 import { formatTrialEndDate } from "../lib/trial-format";
 
 interface SubscribeModalProps {
-  /** Which trigger fired the modal — drives copy. */
-  variant?: "first_fix" | "second_issue" | "paywall" | "cap_hit";
+  /** Which trigger fired the modal — drives copy. `scan_reveal` is the
+   *  launch-arm paywall shown right after the onboarding scan reveals
+   *  findings; it reuses the proof-oriented first_fix copy ("here's what we
+   *  found — start your free trial to fix it"). */
+  variant?: "first_fix" | "second_issue" | "paywall" | "cap_hit" | "scan_reveal";
   /** Called when user dismisses (clicks "Keep my free trial" or backdrop). */
   onDismiss: () => void;
   /** Called after a Checkout URL is opened in the browser. */
@@ -72,7 +75,7 @@ export function SubscribeModal({
     : "Mac";
   const fillDevice = (s: string) => s.replace(/\{device\}/g, device);
   const headline = fillDevice(
-    variant === "first_fix"
+    variant === "first_fix" || variant === "scan_reveal"
       ? t("subscribe.firstFixHeadline")
       : variant === "second_issue"
         ? t("subscribe.secondIssueHeadline")
@@ -87,7 +90,7 @@ export function SubscribeModal({
   );
 
   const body =
-    variant === "first_fix"
+    variant === "first_fix" || variant === "scan_reveal"
       ? t("subscribe.firstFixBody")
       : variant === "second_issue"
         ? t("subscribe.secondIssueBody").replace("{date}", dateLabel)

--- a/apps/desktop/src/lib/tauri-commands.ts
+++ b/apps/desktop/src/lib/tauri-commands.ts
@@ -508,6 +508,14 @@ export interface Entitlement {
   usage_used: number;
   usage_limit: number;
   fix_count_total: number;
+  /**
+   * Paywall-placement A/B arm from the server (deterministic per subject):
+   *  - "launch"    → scan-reveal paywall right after the onboarding scan.
+   *  - "after_fix" → value-first; paywall at the first proven fix.
+   * Absent on older servers — treat missing as "after_fix" (never paywall
+   * aggressively on missing data). See noah-consumer src/lib/paywall.ts.
+   */
+  paywall_placement?: "launch" | "after_fix" | null;
 }
 
 export interface FixCompletedResult {

--- a/apps/desktop/src/stores/consumerStore.ts
+++ b/apps/desktop/src/stores/consumerStore.ts
@@ -6,7 +6,12 @@ export type SubscribeModalVariant =
   | "first_fix"
   | "second_issue"
   | "paywall"
-  | "cap_hit";
+  | "cap_hit"
+  // Launch-arm of the placement A/B: shown right after the onboarding scan
+  // reveals personalized findings — proof first, then "start your free trial
+  // to fix it." The card-on-file trial it opens is identical to every other
+  // variant; only the timing differs.
+  | "scan_reveal";
 
 interface ConsumerState {
   entitlement: Entitlement | null;
@@ -47,6 +52,49 @@ export function isPaywalled(ent: Entitlement | null): boolean {
   if (ent.status === "none" || ent.status === "trialing") return false;
   if (ent.status === "active") return ent.usage_used >= ent.usage_limit;
   return true;
+}
+
+/**
+ * Which paywall-placement arm this subject is in. Defaults to "after_fix"
+ * (value-first) when the server didn't send the field — we never paywall
+ * aggressively on missing/loading data.
+ */
+export function placementArm(ent: Entitlement | null): "launch" | "after_fix" {
+  return ent?.paywall_placement === "launch" ? "launch" : "after_fix";
+}
+
+/** Signals the onboarding orchestrator feeds the placement decision. */
+export interface PaywallSignals {
+  /** The onboarding scan finished and personalized findings are on screen. */
+  scanRevealed: boolean;
+  /** The user has reached at least one real fix this lifetime. */
+  firstFixReached: boolean;
+}
+
+/**
+ * The scan-reveal placement decision (pure). Returns the variant to surface
+ * *right now*, or null. The orchestrator calls this after the onboarding scan
+ * reveals findings and opens the returned variant.
+ *
+ * Launch arm: once the scan has revealed proof, a user who isn't already
+ * trialing/active sees the `scan_reveal` paywall — before spending a free fix.
+ * Already-converted users (trialing with a card, or active) never see it, and
+ * if they somehow already reached a fix we don't interrupt with it.
+ *
+ * After-fix arm: returns null here — that arm's paywall is driven by the
+ * existing first_fix / second_issue / paywall flow, not this launch hook.
+ */
+export function scanRevealPaywallVariant(
+  ent: Entitlement | null,
+  signals: PaywallSignals,
+): SubscribeModalVariant | null {
+  if (!ent) return null;
+  if (placementArm(ent) !== "launch") return null;
+  // Don't interrupt someone who's already in a trial or paying.
+  if (ent.status === "trialing" || ent.status === "active") return null;
+  if (!signals.scanRevealed) return null; // wait for proof
+  if (signals.firstFixReached) return null; // they converted via value already
+  return "scan_reveal";
 }
 
 /**

--- a/apps/desktop/src/stores/placement.test.ts
+++ b/apps/desktop/src/stores/placement.test.ts
@@ -1,0 +1,96 @@
+// Tests for the scan-reveal paywall-placement A/B decision logic.
+import { describe, expect, it } from "vitest";
+
+import type { Entitlement } from "../lib/tauri-commands";
+import { placementArm, scanRevealPaywallVariant } from "./consumerStore";
+
+function ent(overrides: Partial<Entitlement> = {}): Entitlement {
+  return {
+    plan: null,
+    status: "none",
+    trial_started_at: null,
+    trial_ends_at: null,
+    period_start: null,
+    period_end: null,
+    usage_used: 0,
+    usage_limit: 10,
+    fix_count_total: 0,
+    ...overrides,
+  };
+}
+
+describe("placementArm", () => {
+  it("reads the server arm when present", () => {
+    expect(placementArm(ent({ paywall_placement: "launch" }))).toBe("launch");
+    expect(placementArm(ent({ paywall_placement: "after_fix" }))).toBe("after_fix");
+  });
+
+  it("defaults to after_fix (value-first) when missing or null", () => {
+    expect(placementArm(ent())).toBe("after_fix");
+    expect(placementArm(ent({ paywall_placement: null }))).toBe("after_fix");
+    expect(placementArm(null)).toBe("after_fix");
+  });
+});
+
+describe("scanRevealPaywallVariant", () => {
+  const scanned = { scanRevealed: true, firstFixReached: false };
+
+  it("launch arm: shows scan_reveal once the scan has revealed proof", () => {
+    expect(
+      scanRevealPaywallVariant(ent({ paywall_placement: "launch" }), scanned),
+    ).toBe("scan_reveal");
+  });
+
+  it("launch arm: stays silent until the scan reveals findings", () => {
+    expect(
+      scanRevealPaywallVariant(ent({ paywall_placement: "launch" }), {
+        scanRevealed: false,
+        firstFixReached: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("after_fix arm: never fires the launch paywall (handled elsewhere)", () => {
+    expect(
+      scanRevealPaywallVariant(ent({ paywall_placement: "after_fix" }), scanned),
+    ).toBeNull();
+    // missing arm defaults to after_fix → also null
+    expect(scanRevealPaywallVariant(ent(), scanned)).toBeNull();
+  });
+
+  it("never interrupts a user already trialing or active", () => {
+    expect(
+      scanRevealPaywallVariant(
+        ent({ paywall_placement: "launch", status: "trialing" }),
+        scanned,
+      ),
+    ).toBeNull();
+    expect(
+      scanRevealPaywallVariant(
+        ent({ paywall_placement: "launch", status: "active" }),
+        scanned,
+      ),
+    ).toBeNull();
+  });
+
+  it("does not interrupt with the launch paywall once a fix is already reached", () => {
+    expect(
+      scanRevealPaywallVariant(ent({ paywall_placement: "launch" }), {
+        scanRevealed: true,
+        firstFixReached: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("handles a null entitlement safely (still loading)", () => {
+    expect(scanRevealPaywallVariant(null, scanned)).toBeNull();
+  });
+
+  it("re-shows for an expired/canceled launch-arm user (re-acquisition)", () => {
+    for (const status of ["expired", "canceled", "past_due"] as const) {
+      expect(
+        scanRevealPaywallVariant(ent({ paywall_placement: "launch", status }), scanned),
+      ).toBe("scan_reveal");
+    }
+  });
+});

--- a/apps/desktop/src/stores/useScanRevealPaywall.test.tsx
+++ b/apps/desktop/src/stores/useScanRevealPaywall.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import type { Entitlement } from "../lib/tauri-commands";
+import { useConsumerStore } from "./consumerStore";
+import { useScanRevealPaywall } from "./useScanRevealPaywall";
+
+function ent(overrides: Partial<Entitlement> = {}): Entitlement {
+  return {
+    plan: null,
+    status: "none",
+    trial_started_at: null,
+    trial_ends_at: null,
+    period_start: null,
+    period_end: null,
+    usage_used: 0,
+    usage_limit: 10,
+    fix_count_total: 0,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  useConsumerStore.setState({ entitlement: null, subscribeModal: null });
+});
+
+describe("useScanRevealPaywall", () => {
+  it("launch arm: opens scan_reveal once the scan reveals findings", () => {
+    useConsumerStore.setState({ entitlement: ent({ paywall_placement: "launch" }) });
+    const { rerender } = renderHook(
+      (p: { scanRevealed: boolean }) =>
+        useScanRevealPaywall({ scanRevealed: p.scanRevealed, firstFixReached: false }),
+      { initialProps: { scanRevealed: false } },
+    );
+    expect(useConsumerStore.getState().subscribeModal).toBeNull();
+
+    rerender({ scanRevealed: true });
+    expect(useConsumerStore.getState().subscribeModal).toEqual({ variant: "scan_reveal" });
+  });
+
+  it("is one-shot: dismissing it does not re-pop", () => {
+    useConsumerStore.setState({ entitlement: ent({ paywall_placement: "launch" }) });
+    const { rerender } = renderHook(
+      () => useScanRevealPaywall({ scanRevealed: true, firstFixReached: false }),
+    );
+    expect(useConsumerStore.getState().subscribeModal).toEqual({ variant: "scan_reveal" });
+
+    // User picks "Maybe later" → modal closes.
+    useConsumerStore.getState().closeSubscribeModal();
+    expect(useConsumerStore.getState().subscribeModal).toBeNull();
+
+    // A later entitlement refresh re-runs the effect — must NOT re-open.
+    rerender();
+    expect(useConsumerStore.getState().subscribeModal).toBeNull();
+  });
+
+  it("after_fix arm: never opens the launch paywall", () => {
+    useConsumerStore.setState({ entitlement: ent({ paywall_placement: "after_fix" }) });
+    renderHook(() => useScanRevealPaywall({ scanRevealed: true, firstFixReached: false }));
+    expect(useConsumerStore.getState().subscribeModal).toBeNull();
+  });
+
+  it("never interrupts a user already trialing", () => {
+    useConsumerStore.setState({
+      entitlement: ent({ paywall_placement: "launch", status: "trialing" }),
+    });
+    renderHook(() => useScanRevealPaywall({ scanRevealed: true, firstFixReached: false }));
+    expect(useConsumerStore.getState().subscribeModal).toBeNull();
+  });
+
+  it("does not fire before the entitlement has loaded", () => {
+    useConsumerStore.setState({ entitlement: null });
+    renderHook(() => useScanRevealPaywall({ scanRevealed: true, firstFixReached: false }));
+    expect(useConsumerStore.getState().subscribeModal).toBeNull();
+  });
+});

--- a/apps/desktop/src/stores/useScanRevealPaywall.ts
+++ b/apps/desktop/src/stores/useScanRevealPaywall.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+import {
+  scanRevealPaywallVariant,
+  useConsumerStore,
+  type PaywallSignals,
+} from "./consumerStore";
+
+/**
+ * Orchestrator hook for the launch-arm **scan-reveal paywall** — the integration
+ * point that surfaces the paywall in the onboarding flow. Mount it in the
+ * onboarding component and feed it the live signals; when the scan has revealed
+ * findings and a launch-arm user hasn't started a trial, it opens the
+ * `scan_reveal` SubscribeModal.
+ *
+ * **One-shot per mount**: dismissing the paywall ("Maybe later") drops the user
+ * into the after-fix path — we must NOT immediately re-pop it. The ref guards
+ * that, and also guards against re-firing on every entitlement refresh.
+ *
+ * Design-agnostic: this is pure wiring over the tested `scanRevealPaywallVariant`
+ * decision. The onboarding screens (what the scan/reveal look like) plug in
+ * separately by setting `scanRevealed` once their reveal is on screen.
+ */
+export function useScanRevealPaywall(signals: PaywallSignals): void {
+  const entitlement = useConsumerStore((s) => s.entitlement);
+  const subscribeModal = useConsumerStore((s) => s.subscribeModal);
+  const openSubscribeModal = useConsumerStore((s) => s.openSubscribeModal);
+  const firedRef = useRef(false);
+
+  const { scanRevealed, firstFixReached } = signals;
+  useEffect(() => {
+    if (firedRef.current) return; // already shown this onboarding — never re-pop
+    if (subscribeModal) return; // don't stack on an already-open modal
+    const variant = scanRevealPaywallVariant(entitlement, {
+      scanRevealed,
+      firstFixReached,
+    });
+    if (variant) {
+      firedRef.current = true;
+      openSubscribeModal(variant);
+    }
+  }, [entitlement, scanRevealed, firstFixReached, subscribeModal, openSubscribeModal]);
+}


### PR DESCRIPTION
## Goal
Ship the revenue mechanism (card-on-file trial + Apple Pay) and a **scan-reveal paywall with an A/B placement flag**, per the break-even strategy discussion.

## What I found
The **revenue mechanism already exists and is live**: `noah-consumer` creates a Stripe *subscription* Checkout with `trial_period_days` + `payment_method_collection: "always"` — i.e. card-on-file, auto-converts unless cancelled. Stripe **hosted Checkout surfaces Apple Pay automatically** on Mac/Safari, and the desktop opens it in the **system browser** (`openUrl`) where Touch ID works. So the friend's "one Touch ID → trial" is achievable today via Stripe (Apple Pay on the Web) — no App Store / StoreKit needed (we're a notarized-dmg app, so IAP isn't even available to us, and Stripe keeps ~97% vs Apple's cut).

## This PR — the A/B placement (desktop half)
Backend half shipped separately to `noah-consumer` main (`60358e5`): `/entitlement` now returns a deterministic `paywall_placement` arm (`launch` | `after_fix`), no migration, re-derivable for conversion analysis, `PAYWALL_FORCE_ARM` kill-switch.

Desktop primitive here:
- `Entitlement.paywall_placement` type (missing → `after_fix`, never paywall on missing data).
- `placementArm()` + `scanRevealPaywallVariant()` — pure, tested decision logic. Launch arm: once the onboarding scan reveals findings, a not-yet-trialing user gets the paywall *before* spending a free fix; never interrupts a trialing/active user or one who already reached a fix. After-fix arm: existing flow.
- `scan_reveal` SubscribeModal variant (reuses proof-oriented `first_fix` copy).

**Tests:** 9 placement tests + existing store/SubscribeModal tests + `tsc` all green.

## Remaining (handoff — not in this PR)
1. **Onboarding orchestrator wiring**: call `scanRevealPaywallVariant(ent, {scanRevealed, firstFixReached})` after the onboarding scan reveals findings and `openSubscribeModal("scan_reveal")`. (Touches the onboarding flow — a desktop agent has active WIP there, so this should land after that settles.)
2. **An onboarding scan step** if one doesn't exist yet (compose `HealthDashboard`/`FindingsGrid`).
3. Bespoke `scan_reveal` copy (currently reuses `first_fix`).
4. **Deploy `noah-consumer`** (the A/B field is committed to main; deploy is gated on the multi-agent working tree settling).
5. **Live Apple Pay E2E** on a real Mac (Stripe + card in Wallet) — not unit-testable.
