### PR TITLE
paywall(desktop): flag-gated mount of OnboardingFlow (default OFF)

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -16,6 +16,8 @@ import { ProactiveSuggestionBanner } from "./components/ProactiveSuggestionBanne
 import { SessionSummary } from "./components/SessionSummary";
 import { useSessionStore } from "./stores/sessionStore";
 import { TilePickerScreen } from "./components/TilePickerScreen";
+import { OnboardingFlow } from "./components/OnboardingFlow";
+import { flags } from "./lib/flags";
 import { SubscribeModal } from "./components/SubscribeModal";
 import { TrialEmailNudge } from "./components/TrialEmailNudge";
 import { useDebugStore, type DebugEvent } from "./stores/debugStore";
@@ -157,6 +159,13 @@ function App() {
   // both fresh users (pick a problem → sign in) and returning users
   // (tap "Already have an account? Sign in").
   if (needsSetup) {
+    // Flag-gated scan-reveal onboarding (the placement-A/B paywall). Default
+    // OFF — runtime is the existing TilePicker until the flag is flipped and
+    // real diagnostics + the sign-in handoff are wired into OnboardingFlow's
+    // onComplete. See noah-consumer/designs/onboarding/SPEC.md.
+    if (flags.scanRevealOnboarding()) {
+      return <OnboardingFlow onComplete={() => setNeedsSetup(false)} />;
+    }
     return <TilePickerScreen onComplete={() => setNeedsSetup(false)} />;
   }
 

--- a/apps/desktop/src/lib/flags.ts
+++ b/apps/desktop/src/lib/flags.ts
@@ -1,0 +1,24 @@
+/**
+ * Feature flags. Default OFF. Per-device override via localStorage for QA
+ * (no rebuild): `localStorage.setItem("noah.flags.<key>", "1")` to enable,
+ * `"0"` to force-disable. To ship a flag, flip its default below.
+ */
+function flag(key: string, defaultOn: boolean): boolean {
+  try {
+    const v = localStorage.getItem(`noah.flags.${key}`);
+    if (v === "1" || v === "true") return true;
+    if (v === "0" || v === "false") return false;
+  } catch {
+    // localStorage unavailable — fall through to the default.
+  }
+  return defaultOn;
+}
+
+export const flags = {
+  /**
+   * Scan-reveal onboarding + the placement-A/B paywall (OnboardingFlow).
+   * Default OFF until it's mounted-and-released and the real diagnostics are
+   * wired. See noah-consumer/designs/onboarding/SPEC.md.
+   */
+  scanRevealOnboarding: (): boolean => flag("scanRevealOnboarding", false),
+};


### PR DESCRIPTION
Wires the scan-reveal onboarding into App.tsx's first-launch gate behind `flags.scanRevealOnboarding` (default **OFF**). Runtime is unchanged (existing TilePicker); the active onboarding agent's `TilePickerScreen.tsx` is untouched. The paywall flow is now **one flag-flip from live**.

**To ship:** flip the default in `lib/flags.ts` (or set `localStorage noah.flags.scanRevealOnboarding=1` for QA), wire real diagnostics into `OnboardingFlow`'s `findingsByProblem`, handle the sign-in/seed handoff in `onComplete`, then cut a release. Apple Pay E2E on a real Mac.

tsc clean; 59 tests pass incl. the 37 onboarding tests (flag-off path unchanged).