### PR TITLE
paywall(desktop): wire real diagnostics into the onboarding reveal

### DIFF
--- a/apps/desktop/src/components/OnboardingFlow.test.tsx
+++ b/apps/desktop/src/components/OnboardingFlow.test.tsx
@@ -2,9 +2,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import type { Entitlement } from "../lib/tauri-commands";
+import type { Entitlement, HealthScore } from "../lib/tauri-commands";
 import { useConsumerStore } from "../stores/consumerStore";
 import { OnboardingFlow } from "./OnboardingFlow";
+
+const liveScore: HealthScore = {
+  overall_score: 60, overall_grade: "C",
+  categories: [{ category: "memory", score: 60, grade: "C", checks: [
+    { id: "m", category: "memory", label: "RAM almost full", status: "fail", detail: "9 GB used" },
+  ] }],
+  computed_at: "now", device_id: null,
+};
 
 function setArm(placement: "launch" | "after_fix", extra: Partial<Entitlement> = {}) {
   useConsumerStore.setState({
@@ -66,6 +74,24 @@ describe("OnboardingFlow", () => {
     fireEvent.click(screen.getByText("Look into it →"));
     // storage-specific diagnosis card (headline text is split across spans)
     await waitFor(() => expect(screen.getByText("Reclaimable now")).toBeTruthy());
+  });
+
+  it("uses LIVE diagnostics when the scan returns findings", async () => {
+    setArm("after_fix");
+    render(<OnboardingFlow onComplete={() => {}} scanDurationMs={0} fetchHealthScore={async () => liveScore} />);
+    fireEvent.click(screen.getByText("Get started"));
+    fireEvent.click(screen.getByText("Look into it →"));
+    await waitFor(() => expect(screen.getByText("RAM almost full")).toBeTruthy());
+    // the curated default must NOT show when real data is present
+    expect(screen.queryByText("Tied up by Chrome + 47 tabs")).toBeNull();
+  });
+
+  it("falls back to curated defaults when live diagnostics are empty", async () => {
+    setArm("after_fix");
+    render(<OnboardingFlow onComplete={() => {}} scanDurationMs={0} fetchHealthScore={async () => null} />);
+    fireEvent.click(screen.getByText("Get started"));
+    fireEvent.click(screen.getByText("Look into it →"));
+    await waitFor(() => expect(screen.getByText("Tied up by Chrome + 47 tabs")).toBeTruthy());
   });
 
   it("the reveal CTA completes onboarding", async () => {

--- a/apps/desktop/src/components/OnboardingFlow.tsx
+++ b/apps/desktop/src/components/OnboardingFlow.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react";
+import { getHealthScore, type HealthScore } from "../lib/tauri-commands";
+import { findingsFromHealthScore } from "../lib/onboarding-findings";
 import { useConsumerStore } from "../stores/consumerStore";
 import { useScanRevealPaywall } from "../stores/useScanRevealPaywall";
 
@@ -18,7 +20,10 @@ type Tone = "bad" | "warn" | "ok";
 
 export interface Finding {
   tone: Tone;
-  big: string;
+  /** Punchy headline value ("9.1 GB", "12 apps"). Optional — real diagnostic
+   *  checks don't always have a clean number, in which case the card leads with
+   *  the label. */
+  big?: string;
   label: string;
   detail: string;
 }
@@ -30,8 +35,10 @@ export interface OnboardingFlowProps {
   initialProblem?: string;
   /** Scan dwell before the reveal. Override (e.g. 0) in tests. */
   scanDurationMs?: number;
-  /** Diagnosis cards per problem. Defaults to the built-in set. */
+  /** Diagnosis cards per problem. Fallback when the live scan finds nothing. */
   findingsByProblem?: Record<string, Finding[]>;
+  /** Diagnostics source. Defaults to the real `getHealthScore`; injectable for tests. */
+  fetchHealthScore?: () => Promise<HealthScore | null>;
 }
 
 const PROBLEMS: { id: string; emoji: string; title: string; sub: string }[] = [
@@ -73,9 +80,11 @@ export function OnboardingFlow({
   initialProblem,
   scanDurationMs = 2600,
   findingsByProblem = DEFAULT_FINDINGS,
+  fetchHealthScore = getHealthScore,
 }: OnboardingFlowProps) {
   const [step, setStep] = useState<Step>("welcome");
   const [problem, setProblem] = useState(initialProblem ?? "slow");
+  const [liveFindings, setLiveFindings] = useState<Finding[] | null>(null);
   const fixCount = useConsumerStore((s) => s.entitlement?.fix_count_total ?? 0);
 
   // The integration: once the reveal is on screen, surface the launch-arm
@@ -84,11 +93,25 @@ export function OnboardingFlow({
 
   useEffect(() => {
     if (step !== "scan") return;
+    let active = true;
+    // Real diagnosis: fetch the health score during the scan dwell and map it
+    // to findings. Falls back to the curated defaults if it's empty or errors,
+    // so the reveal is never blank.
+    void fetchHealthScore()
+      .then((score) => {
+        if (!active) return;
+        const mapped = findingsFromHealthScore(score, problem);
+        if (mapped.length) setLiveFindings(mapped);
+      })
+      .catch(() => {});
     const id = setTimeout(() => setStep("reveal"), scanDurationMs);
-    return () => clearTimeout(id);
-  }, [step, scanDurationMs]);
+    return () => {
+      active = false;
+      clearTimeout(id);
+    };
+  }, [step, scanDurationMs, problem, fetchHealthScore]);
 
-  const findings = findingsByProblem[problem] ?? findingsByProblem.slow ?? [];
+  const findings = liveFindings ?? findingsByProblem[problem] ?? findingsByProblem.slow ?? [];
 
   return (
     <div className="fixed inset-0 z-40 flex flex-col items-center justify-center px-8 text-center bg-bg-primary"
@@ -153,8 +176,8 @@ export function OnboardingFlow({
                 <span className="w-8 h-8 flex-none grid place-items-center rounded-lg text-base font-bold"
                       style={{ background: TONE[f.tone].bg, color: TONE[f.tone].fg }}>{TONE[f.tone].mark}</span>
                 <span>
-                  <span className="block text-[19px] font-bold leading-none text-text-primary">{f.big}</span>
-                  <span className="block text-[13px] font-semibold mt-1 text-text-primary">{f.label}</span>
+                  {f.big && <span className="block text-[19px] font-bold leading-none text-text-primary">{f.big}</span>}
+                  <span className={"block text-[13px] font-semibold text-text-primary" + (f.big ? " mt-1" : "")}>{f.label}</span>
                   <span className="block text-[12px] text-text-muted mt-0.5">{f.detail}</span>
                 </span>
               </div>

--- a/apps/desktop/src/lib/onboarding-findings.test.ts
+++ b/apps/desktop/src/lib/onboarding-findings.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { CheckResult, HealthScore } from "./tauri-commands";
+import { findingsFromHealthScore } from "./onboarding-findings";
+
+function check(over: Partial<CheckResult>): CheckResult {
+  return { id: "x", category: "general", label: "L", status: "pass", detail: "d", ...over };
+}
+function score(checks: CheckResult[]): HealthScore {
+  return {
+    overall_score: 70, overall_grade: "C",
+    categories: [{ category: "mixed", score: 70, grade: "C", checks }],
+    computed_at: "now", device_id: null,
+  };
+}
+
+describe("findingsFromHealthScore", () => {
+  it("returns [] for null / empty input", () => {
+    expect(findingsFromHealthScore(null, "slow")).toEqual([]);
+    expect(findingsFromHealthScore(score([]), "slow")).toEqual([]);
+  });
+
+  it("maps status → tone and carries label/detail", () => {
+    const out = findingsFromHealthScore(score([
+      check({ status: "fail", label: "Low memory", detail: "9 GB used", category: "memory" }),
+    ]), "slow");
+    expect(out[0]).toMatchObject({ tone: "bad", label: "Low memory", detail: "9 GB used" });
+    expect(out[0]!.big).toBeUndefined(); // real checks lead with the label
+  });
+
+  it("leads with issues (fail before warn before pass)", () => {
+    const out = findingsFromHealthScore(score([
+      check({ status: "pass", label: "Firewall on" }),
+      check({ status: "warn", label: "Startup heavy" }),
+      check({ status: "fail", label: "Disk almost full" }),
+    ]), "slow");
+    expect(out.map((f) => f.label)).toEqual(["Disk almost full", "Startup heavy", "Firewall on"]);
+  });
+
+  it("within a tier, surfaces the user's problem area first", () => {
+    const out = findingsFromHealthScore(score([
+      check({ status: "warn", label: "Old backups", category: "backup" }),
+      check({ status: "warn", label: "RAM pressure", category: "memory" }),
+    ]), "slow");
+    expect(out[0]!.label).toBe("RAM pressure"); // slow → memory is on-topic
+  });
+
+  it("matches the problem area by category OR label text", () => {
+    const out = findingsFromHealthScore(score([
+      check({ status: "warn", label: "Time Machine overdue", category: "general" }),
+      check({ status: "warn", label: "Something", category: "other" }),
+    ]), "backup");
+    expect(out[0]!.label).toBe("Time Machine overdue"); // matched via label text
+  });
+
+  it("caps at max and includes a passing check as reassurance when room", () => {
+    const out = findingsFromHealthScore(score([
+      check({ status: "fail", label: "A" }),
+      check({ status: "warn", label: "B" }),
+      check({ status: "pass", label: "C-ok" }),
+      check({ status: "pass", label: "D-ok" }),
+      check({ status: "warn", label: "E" }),
+    ]), "slow", 4);
+    expect(out).toHaveLength(4);
+    expect(out.filter((f) => f.tone !== "ok").length).toBeGreaterThanOrEqual(3); // issues lead
+    expect(out.some((f) => f.tone === "ok")).toBe(true); // one reassurance card
+  });
+});

--- a/apps/desktop/src/lib/onboarding-findings.ts
+++ b/apps/desktop/src/lib/onboarding-findings.ts
@@ -1,0 +1,77 @@
+import type { CheckResult, HealthScore } from "./tauri-commands";
+import type { Finding } from "../components/OnboardingFlow";
+
+/**
+ * Turn a real `HealthScore` (the same diagnostics behind the Mac Health
+ * dashboard) into the onboarding **diagnosis** cards — leading with the issues
+ * relevant to the problem the user picked, so the reveal answers *their*
+ * question ("why is it slow?"), not a generic report.
+ *
+ * Pure + testable. The onboarding scan step calls `getHealthScore()` and passes
+ * the result through this; until that wiring lands, OnboardingFlow's built-in
+ * defaults stand in.
+ */
+
+// Which health categories speak to each problem. Matched case-insensitively as
+// substrings so we're robust to "Performance"/"perf"/"memory" naming.
+const PROBLEM_CATEGORIES: Record<string, string[]> = {
+  slow: ["performance", "memory", "cpu", "startup", "process"],
+  storage: ["storage", "disk", "space"],
+  wifi: ["network", "wifi", "wi-fi", "dns"],
+  security: ["security", "firewall", "privacy", "malware"],
+  backup: ["backup", "time machine", "snapshot"],
+};
+
+const STATUS_TONE: Record<CheckResult["status"], Finding["tone"]> = {
+  fail: "bad",
+  warn: "warn",
+  pass: "ok",
+};
+
+function onTopic(check: CheckResult, problem: string): boolean {
+  const cats = PROBLEM_CATEGORIES[problem] ?? [];
+  const hay = `${check.category} ${check.label}`.toLowerCase();
+  return cats.some((c) => hay.includes(c));
+}
+
+/**
+ * @param max  cap the cards (the grid shows ~4 cleanly).
+ * @returns issues first (fail before warn), the user's problem area first
+ *   within each tier; a passing on-topic check is included last as reassurance
+ *   ("you're fine here") so the reveal isn't all doom.
+ */
+export function findingsFromHealthScore(
+  score: HealthScore | null | undefined,
+  problem: string,
+  max = 4,
+): Finding[] {
+  if (!score || !Array.isArray(score.categories)) return [];
+  const checks = score.categories.flatMap((c) => c.checks ?? []);
+
+  const sevRank = (s: CheckResult["status"]): number =>
+    s === "fail" ? 0 : s === "warn" ? 1 : 2;
+
+  const ranked = [...checks].sort((a, b) => {
+    const sa = sevRank(a.status);
+    const sb = sevRank(b.status);
+    if (sa !== sb) return sa - sb; // issues before passes
+    const ta = onTopic(a, problem) ? 0 : 1;
+    const tb = onTopic(b, problem) ? 0 : 1;
+    return ta - tb; // problem area first within a severity tier
+  });
+
+  // Lead with real issues; only pad with passing (reassurance) checks if we
+  // have room and there's at least one issue worth showing.
+  const issues = ranked.filter((c) => c.status !== "pass");
+  const passes = ranked.filter((c) => c.status === "pass");
+  const chosen = issues.length
+    ? [...issues, ...passes].slice(0, max)
+    : ranked.slice(0, max);
+
+  return chosen.map((c) => ({
+    tone: STATUS_TONE[c.status],
+    label: c.label,
+    detail: c.detail,
+    // real checks rarely carry a clean headline number → label-led card
+  }));
+}


### PR DESCRIPTION
OnboardingFlow's reveal now uses the **real** HealthScore (same diagnostics as Mac Health), mapped via `findingsFromHealthScore` — issues first, the user's problem area prioritized, graceful fallback to curated defaults. `Finding.big` optional. Still flag-OFF/dormant. 32 paywall tests pass, tsc clean. Remaining to ship: sign-in/seed handoff (agent's TilePicker), flag flip + release, Apple Pay E2E.