### PR TITLE
paywall(i18n): localize the scan_reveal paywall copy (en/zh/es)

### DIFF
--- a/apps/desktop/src/components/SubscribeModal.tsx
+++ b/apps/desktop/src/components/SubscribeModal.tsx
@@ -77,14 +77,13 @@ export function SubscribeModal({
 
   // scan_reveal is shown to a brand-new user and starts a CARD-ON-FILE trial
   // (Apple Pay). So it must NOT reuse the "no card" copy — that would be a
-  // bait-and-switch. Honest, plain terms instead. (English inline for now;
-  // i18n before this flag ships.)
+  // bait-and-switch. Honest, plain terms via subscribe.scanReveal.* (en/zh/es).
   const scanReveal = variant === "scan_reveal";
   const priceLabel = `${t(`subscribe.plan.${plan}.price`)}${t(`subscribe.plan.${plan}.priceUnit`)}`;
 
   const headline = fillDevice(
     scanReveal
-      ? "Start your free trial"
+      ? t("subscribe.scanReveal.headline")
       : variant === "first_fix"
         ? t("subscribe.firstFixHeadline")
         : variant === "second_issue"
@@ -101,7 +100,7 @@ export function SubscribeModal({
 
   const body =
     scanReveal
-      ? "Noah fixes what we found — and stays for whatever's next: storage, Wi-Fi, backups, security."
+      ? t("subscribe.scanReveal.body")
       : variant === "first_fix"
       ? t("subscribe.firstFixBody")
       : variant === "second_issue"
@@ -137,7 +136,7 @@ export function SubscribeModal({
               color: "var(--color-accent-indigo)",
             }}
           >
-            {scanReveal ? "7 days free · cancel anytime" : t("subscribe.trustPill")}
+            {scanReveal ? t("subscribe.scanReveal.pill") : t("subscribe.trustPill")}
           </span>
           <h3 className="text-[24px] font-semibold text-text-primary leading-[1.15] tracking-tight">
             {headline}
@@ -226,7 +225,7 @@ export function SubscribeModal({
             disabled={loading}
             className="w-full py-3.5 rounded-2xl text-[15.5px] font-semibold cursor-pointer disabled:opacity-50 btn-commit"
           >
-            {loading ? t("subscribe.opening") : scanReveal ? "Start free trial" : t("subscribe.subscribe")}
+            {loading ? t("subscribe.opening") : scanReveal ? t("subscribe.scanReveal.cta") : t("subscribe.subscribe")}
           </button>
           {/* Trust footnote — lives BELOW the CTA, not above it. The
               user has already seen the headline and the price; this
@@ -239,7 +238,7 @@ export function SubscribeModal({
             {isPostCheckoutPolling
               ? t("subscribe.alreadyPaidNote")
               : scanReveal
-                ? `$0 today · 7 days free, then ${priceLabel} · cancel anytime — we'll remind you before it renews`
+                ? t("subscribe.scanReveal.footnote", { price: priceLabel })
                 : t("subscribe.footnote")}
           </p>
 
@@ -247,7 +246,7 @@ export function SubscribeModal({
             onClick={onDismiss}
             className="w-full mt-2 py-2 text-[12.5px] text-text-muted hover:text-text-secondary transition-colors cursor-pointer"
           >
-            {scanReveal ? "Maybe later" : t("subscribe.keepTrial")}
+            {scanReveal ? t("subscribe.scanReveal.maybeLater") : t("subscribe.keepTrial")}
           </button>
         </div>
 

--- a/apps/desktop/src/i18n/en.json
+++ b/apps/desktop/src/i18n/en.json
@@ -141,7 +141,15 @@
     "keepTrial": "Not yet — keep my free trial",
     "subscribe": "Keep Noah",
     "opening": "Opening checkout…",
-    "fixContinuesNote": "Either way, Noah keeps fixing this in the background."
+    "fixContinuesNote": "Either way, Noah keeps fixing this in the background.",
+    "scanReveal": {
+      "headline": "Start your free trial",
+      "body": "Noah fixes what we found — and stays for whatever's next: storage, Wi-Fi, backups, security.",
+      "pill": "7 days free · cancel anytime",
+      "cta": "Start free trial",
+      "footnote": "$0 today · 7 days free, then {price} · cancel anytime — we'll remind you before it renews",
+      "maybeLater": "Maybe later"
+    }
   },
   "trialBanner": {
     "lead": "Noah is yours to use",

--- a/apps/desktop/src/i18n/es.json
+++ b/apps/desktop/src/i18n/es.json
@@ -64,7 +64,15 @@
     "keepTrial": "Aún no — mantener mi prueba gratuita",
     "subscribe": "Mantener Noah",
     "opening": "Abriendo el pago…",
-    "fixContinuesNote": "Igual, Noah sigue arreglando esto en segundo plano."
+    "fixContinuesNote": "Igual, Noah sigue arreglando esto en segundo plano.",
+    "scanReveal": {
+      "headline": "Empieza tu prueba gratis",
+      "body": "Noah arregla lo que encontramos — y se queda para lo que venga: almacenamiento, Wi-Fi, copias de seguridad, seguridad.",
+      "pill": "7 días gratis · cancela cuando quieras",
+      "cta": "Empezar prueba gratis",
+      "footnote": "$0 hoy · 7 días gratis, luego {price} · cancela cuando quieras — te avisaremos antes de la renovación",
+      "maybeLater": "Quizás más tarde"
+    }
   },
   "trialBanner": {
     "lead": "Noah es tuyo para usar",

--- a/apps/desktop/src/i18n/zh.json
+++ b/apps/desktop/src/i18n/zh.json
@@ -330,7 +330,15 @@
     "keepTrial": "暂时不用 — 继续我的免费试用",
     "subscribe": "继续使用 Noah",
     "opening": "正在打开结账…",
-    "fixContinuesNote": "不管怎样，Noah 都会在后台继续修复这个问题。"
+    "fixContinuesNote": "不管怎样，Noah 都会在后台继续修复这个问题。",
+    "scanReveal": {
+      "headline": "开始免费试用",
+      "body": "Noah 会修复我们发现的问题——并继续帮你应对接下来的一切：存储、Wi-Fi、备份、安全。",
+      "pill": "7 天免费 · 随时取消",
+      "cta": "开始免费试用",
+      "footnote": "今天 $0 · 7 天免费，之后 {price} · 随时取消——续费前我们会提醒你",
+      "maybeLater": "以后再说"
+    }
   },
   "trialBanner": {
     "lead": "Noah 是你的",


### PR DESCRIPTION
The conversion/honesty-critical `scan_reveal` paywall copy is now in `subscribe.scanReveal.*` across en/zh/es (no inline English in the paywall). i18n parity + tsc green. Remaining: the OnboardingFlow chrome strings (styled spans, native-review) before the flag ships.