### PR TITLE
telemetry + onboarding: conversation telemetry + drop the clarifier step

### DIFF
--- a/apps/desktop/src-tauri/src/agent/llm_client.rs
+++ b/apps/desktop/src-tauri/src/agent/llm_client.rs
@@ -393,6 +393,11 @@ impl LlmClient {
             .post(self.api_url())
             .header("anthropic-version", API_VERSION)
             .header("content-type", "application/json")
+            // Metadata side-call (title / summary / diagnostic / triage) —
+            // NOT a conversation turn. noah-consumer skips telemetry
+            // capture for any x-noah-call-kind other than "chat", so these
+            // never get recorded as something the user or Noah "said".
+            .header("x-noah-call-kind", "meta")
             .json(&body);
         let resp = self
             .apply_auth(builder)
@@ -441,6 +446,11 @@ impl LlmClient {
             .post(self.api_url())
             .header("anthropic-version", API_VERSION)
             .header("content-type", "application/json")
+            // Metadata side-call (title / summary / diagnostic / triage) —
+            // NOT a conversation turn. noah-consumer skips telemetry
+            // capture for any x-noah-call-kind other than "chat", so these
+            // never get recorded as something the user or Noah "said".
+            .header("x-noah-call-kind", "meta")
             .json(&body);
         let resp = self
             .apply_auth(builder)
@@ -515,6 +525,11 @@ impl LlmClient {
             .post(self.api_url())
             .header("anthropic-version", API_VERSION)
             .header("content-type", "application/json")
+            // Metadata side-call (title / summary / diagnostic / triage) —
+            // NOT a conversation turn. noah-consumer skips telemetry
+            // capture for any x-noah-call-kind other than "chat", so these
+            // never get recorded as something the user or Noah "said".
+            .header("x-noah-call-kind", "meta")
             .json(&body);
         let resp = self
             .apply_auth(builder)
@@ -580,6 +595,11 @@ impl LlmClient {
             .post(self.api_url())
             .header("anthropic-version", API_VERSION)
             .header("content-type", "application/json")
+            // Metadata side-call (title / summary / diagnostic / triage) —
+            // NOT a conversation turn. noah-consumer skips telemetry
+            // capture for any x-noah-call-kind other than "chat", so these
+            // never get recorded as something the user or Noah "said".
+            .header("x-noah-call-kind", "meta")
             .json(&body);
         let resp = self
             .apply_auth(builder)
@@ -659,6 +679,11 @@ impl LlmClient {
             .post(self.api_url())
             .header("anthropic-version", API_VERSION)
             .header("content-type", "application/json")
+            // Metadata side-call (title / summary / diagnostic / triage) —
+            // NOT a conversation turn. noah-consumer skips telemetry
+            // capture for any x-noah-call-kind other than "chat", so these
+            // never get recorded as something the user or Noah "said".
+            .header("x-noah-call-kind", "meta")
             .json(&body);
         let resp = self
             .apply_auth(builder)
@@ -704,6 +729,12 @@ impl LlmClient {
         messages: Vec<Message>,
         tools: Vec<ToolDef>,
         system: Vec<crate::agent::prompts::SystemBlock>,
+        // Desktop session id = the Noah conversation/issue this turn
+        // belongs to. Sent as X-Conversation-Id so noah-consumer can
+        // group every turn (and survive a device→user identity switch
+        // at purchase, which keeps the same session id). None for
+        // contexts without a session (e.g. one-off auth pings).
+        conversation_id: Option<&str>,
     ) -> Result<Response> {
         let body = ApiRequest {
             model: effective_model(),
@@ -723,12 +754,18 @@ impl LlmClient {
                 tokio::time::sleep(delay).await;
             }
 
-            let builder = self
+            let mut builder = self
                 .client
                 .post(self.api_url())
                 .header("anthropic-version", API_VERSION)
                 .header("content-type", "application/json")
-                .json(&body);
+                // Real conversation turn — the one call kind noah-consumer
+                // records. Carries the conversation id when we have one.
+                .header("x-noah-call-kind", "chat");
+            if let Some(cid) = conversation_id {
+                builder = builder.header("x-conversation-id", cid);
+            }
+            let builder = builder.json(&body);
             let resp = match self.apply_auth(builder).send().await {
                 Ok(r) => r,
                 Err(e) => {

--- a/apps/desktop/src-tauri/src/agent/orchestrator.rs
+++ b/apps/desktop/src-tauri/src/agent/orchestrator.rs
@@ -407,7 +407,7 @@ impl Orchestrator {
 
             let response = match self
                 .llm
-                .send_message(messages.clone(), tool_defs.clone(), system.clone())
+                .send_message(messages.clone(), tool_defs.clone(), system.clone(), Some(session_id))
                 .await
             {
                 Ok(response) => response,
@@ -429,7 +429,7 @@ impl Orchestrator {
                             .await?;
                         let retry_messages = self.messages_for_llm(session_id);
                         self.llm
-                            .send_message(retry_messages, tool_defs.clone(), system.clone())
+                            .send_message(retry_messages, tool_defs.clone(), system.clone(), Some(session_id))
                             .await?
                     } else {
                         return Err(err);

--- a/apps/desktop/src-tauri/src/commands/agent.rs
+++ b/apps/desktop/src-tauri/src/commands/agent.rs
@@ -392,11 +392,38 @@ async fn run_agent_turn(
         let msg = message.clone();
         let sid = session_id.clone();
         let db: Arc<Mutex<rusqlite::Connection>> = Arc::clone(&state.db);
+        let app_dir = state.app_dir.clone();
         Some(tokio::spawn(async move {
             if let Ok(title) = llm.generate_title(&msg).await {
-                let conn = db.lock().await;
-                if let Err(e) = journal::update_session_title(&conn, &sid, &title) {
-                    eprintln!("[warn] Failed to set session title: {}", e);
+                {
+                    let conn = db.lock().await;
+                    if let Err(e) = journal::update_session_title(&conn, &sid, &title) {
+                        eprintln!("[warn] Failed to set session title: {}", e);
+                    }
+                }
+                // Report the authoritative title to the backend, keyed by
+                // conversation (session) id. The proxy can't capture this —
+                // title generation is a metadata side-call we deliberately
+                // exclude from telemetry — so the desktop is the only source.
+                // Best-effort: telemetry must never disturb the chat flow.
+                let sess = crate::consumer::session::get_session_token(&app_dir)
+                    .ok()
+                    .flatten();
+                let dev = crate::consumer::device::ensure_device_id(&app_dir).ok();
+                let auth = if let Some(t) = sess.as_deref() {
+                    Some(crate::consumer::client::Auth::Session(t))
+                } else {
+                    dev.as_deref().map(crate::consumer::client::Auth::Device)
+                };
+                if let Some(auth) = auth {
+                    let _ = crate::consumer::client::notify_issue_started(
+                        &auth,
+                        None,
+                        Some(&sid),
+                        Some(&title),
+                        None,
+                    )
+                    .await;
                 }
             }
         }))

--- a/apps/desktop/src-tauri/src/commands/consumer.rs
+++ b/apps/desktop/src-tauri/src/commands/consumer.rs
@@ -132,14 +132,23 @@ pub async fn consumer_get_entitlement(
 pub async fn consumer_notify_issue_started(
     state: State<'_, AppState>,
     tz_offset_minutes: Option<i32>,
+    conversation_id: Option<String>,
+    title: Option<String>,
+    text: Option<String>,
 ) -> Result<Option<client::Entitlement>, String> {
     let (session_tok, device_id) = current_auth(&state.app_dir);
     let Some(auth) = auth_ref(&session_tok, &device_id) else {
         return Ok(None);
     };
-    let ent = client::notify_issue_started(&auth, tz_offset_minutes)
-        .await
-        .map_err(|e| e.to_string())?;
+    let ent = client::notify_issue_started(
+        &auth,
+        tz_offset_minutes,
+        conversation_id.as_deref(),
+        title.as_deref(),
+        text.as_deref(),
+    )
+    .await
+    .map_err(|e| e.to_string())?;
     let _ = entitlement::save_cached(&state.app_dir, &ent);
     Ok(Some(ent))
 }
@@ -170,14 +179,20 @@ pub async fn consumer_trial_link_email(
 #[tauri::command]
 pub async fn consumer_notify_fix_completed(
     state: State<'_, AppState>,
+    conversation_id: Option<String>,
+    outcome: Option<String>,
 ) -> Result<Option<client::FixCompletedResponse>, String> {
     let (session_tok, device_id) = current_auth(&state.app_dir);
     let Some(auth) = auth_ref(&session_tok, &device_id) else {
         return Ok(None);
     };
-    let result = client::notify_fix_completed(&auth)
-        .await
-        .map_err(|e| e.to_string())?;
+    let result = client::notify_fix_completed(
+        &auth,
+        conversation_id.as_deref(),
+        outcome.as_deref(),
+    )
+    .await
+    .map_err(|e| e.to_string())?;
     let _ = entitlement::save_cached(&state.app_dir, &result.entitlement);
     Ok(Some(result))
 }

--- a/apps/desktop/src-tauri/src/commands/consumer.rs
+++ b/apps/desktop/src-tauri/src/commands/consumer.rs
@@ -129,6 +129,19 @@ pub async fn consumer_get_entitlement(
 }
 
 #[tauri::command]
+pub async fn consumer_notify_app_open(
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let (session_tok, device_id) = current_auth(&state.app_dir);
+    let Some(auth) = auth_ref(&session_tok, &device_id) else {
+        return Ok(());
+    };
+    // Best-effort beacon — never surface an error to the UI.
+    let _ = client::notify_app_open(&auth).await;
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn consumer_notify_issue_started(
     state: State<'_, AppState>,
     tz_offset_minutes: Option<i32>,

--- a/apps/desktop/src-tauri/src/consumer/client.rs
+++ b/apps/desktop/src-tauri/src/consumer/client.rs
@@ -127,10 +127,22 @@ pub async fn fetch_entitlement(auth: &Auth<'_>) -> Result<Entitlement> {
 pub async fn notify_issue_started(
     auth: &Auth<'_>,
     tz_offset_minutes: Option<i32>,
+    // Conversation/issue context. All optional and ignored by older
+    // server builds — `conversation_id` is the session id, `title` the
+    // generated issue title (reported once it exists), `text` the
+    // verbatim opening prompt.
+    conversation_id: Option<&str>,
+    title: Option<&str>,
+    text: Option<&str>,
 ) -> Result<Entitlement> {
     let req = client()
         .post(format!("{}/events/issue-started", base_url()))
-        .json(&serde_json::json!({ "tz_offset_minutes": tz_offset_minutes }));
+        .json(&serde_json::json!({
+            "tz_offset_minutes": tz_offset_minutes,
+            "conversation_id": conversation_id,
+            "title": title,
+            "text": text,
+        }));
     let resp = apply_auth(req, auth).send().await?;
     if !resp.status().is_success() {
         return Err(anyhow!("issue-started failed: {}", resp.status()));
@@ -155,8 +167,19 @@ pub async fn trial_link_email(auth: &Auth<'_>, email: &str) -> Result<()> {
     Ok(())
 }
 
-pub async fn notify_fix_completed(auth: &Auth<'_>) -> Result<FixCompletedResponse> {
-    let req = client().post(format!("{}/events/fix-completed", base_url()));
+pub async fn notify_fix_completed(
+    auth: &Auth<'_>,
+    // Optional conversation context — marks the issue resolved with its
+    // outcome. Ignored by older server builds.
+    conversation_id: Option<&str>,
+    outcome: Option<&str>,
+) -> Result<FixCompletedResponse> {
+    let req = client()
+        .post(format!("{}/events/fix-completed", base_url()))
+        .json(&serde_json::json!({
+            "conversation_id": conversation_id,
+            "outcome": outcome,
+        }));
     let resp = apply_auth(req, auth).send().await?;
     if !resp.status().is_success() {
         return Err(anyhow!("fix-completed failed: {}", resp.status()));

--- a/apps/desktop/src-tauri/src/consumer/client.rs
+++ b/apps/desktop/src-tauri/src/consumer/client.rs
@@ -124,6 +124,19 @@ pub async fn fetch_entitlement(auth: &Auth<'_>) -> Result<Entitlement> {
     Ok(resp.json().await?)
 }
 
+/// Fire-and-forget "app opened" beacon — the activation signal. Sent
+/// once per launch before any message, so a device that opens the app
+/// and bounces without asking anything is still counted. No body; the
+/// server ensures the entitlement row and stamps last_seen.
+pub async fn notify_app_open(auth: &Auth<'_>) -> Result<()> {
+    let req = client().post(format!("{}/events/app-open", base_url()));
+    let resp = apply_auth(req, auth).send().await?;
+    if !resp.status().is_success() {
+        return Err(anyhow!("app-open failed: {}", resp.status()));
+    }
+    Ok(())
+}
+
 pub async fn notify_issue_started(
     auth: &Auth<'_>,
     tz_offset_minutes: Option<i32>,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -722,6 +722,7 @@ pub fn run() {
             commands::consumer::consumer_complete_sign_in,
             commands::consumer::consumer_sign_out,
             commands::consumer::consumer_get_entitlement,
+            commands::consumer::consumer_notify_app_open,
             commands::consumer::consumer_notify_issue_started,
             commands::consumer::consumer_notify_fix_completed,
             commands::consumer::consumer_billing_checkout_url,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -67,7 +67,13 @@ function App() {
   // empty journal lands back on the 8-tile picker after sign-in,
   // which feels broken — they already onboarded.
   useEffect(() => {
-    commands.consumerEnsureDeviceId().catch(() => {});
+    // Ensure the device id exists, then fire the activation beacon so a
+    // device that opens the app (even if it never asks anything) is
+    // counted in the funnel. Best-effort; never blocks startup.
+    commands
+      .consumerEnsureDeviceId()
+      .then(() => commands.consumerNotifyAppOpen())
+      .catch(() => {});
     // Use a sentinel so an errored probe fails *open* (skip tiles).
     // Stranding the user on the gate is worse than skipping it once.
     Promise.all([

--- a/apps/desktop/src/components/ChatPanel.tsx
+++ b/apps/desktop/src/components/ChatPanel.tsx
@@ -1027,7 +1027,10 @@ function DoneCard({
     // to surface here.
     if (value) {
       try {
-        const result = await commands.consumerNotifyFixCompleted();
+        const result = await commands.consumerNotifyFixCompleted(
+          sessionId,
+          summary,
+        );
         if (result) {
           useConsumerStore.getState().setEntitlement(result.entitlement);
         }

--- a/apps/desktop/src/components/TilePickerScreen.tsx
+++ b/apps/desktop/src/components/TilePickerScreen.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState } from "react";
 import type { LucideIcon } from "lucide-react";
 import {
   AlertTriangle,
-  ArrowLeft,
   BatteryLow,
   Cloud,
   Gauge,
@@ -44,26 +43,23 @@ const TILES: readonly Tile[] = [
 
 type Stage =
   | { name: "pick" }
-  | { name: "clarify"; tile: Tile }
   | { name: "signin"; tile: Tile | null; seedMessage: string | null };
 
 /**
  * First-run entry for users without a session. Shows a grid of eight
- * common Mac problems ("Pick One") and, once the user picks, collects
- * a short clarifier and routes into the magic-link sign-in. The
- * seed message (category + clarifier) is persisted to localStorage so
- * it survives the browser magic-link round-trip and seeds the first
- * chat turn on return.
+ * common Mac problems ("Pick One"). Picking a concrete tile goes
+ * STRAIGHT into the diagnosis — the tile IS the statement of intent, so
+ * we seed it as the first chat turn and let Noah ask for any specifics
+ * conversationally. (We used to route every pick through a full-screen
+ * clarifier textarea; even though typing was optional, the box read as
+ * "you must type" and bounced people on first run.) The "other" tile,
+ * which has no preset problem, opens the chat empty so the user can
+ * describe it there. No sign-in required; the device's anonymous trial
+ * starts when the server sees /events/issue-started.
  */
 export function TilePickerScreen({ onComplete }: TilePickerScreenProps) {
   const { t } = useLocale();
   const [stage, setStage] = useState<Stage>({ name: "pick" });
-  const [clarifier, setClarifier] = useState("");
-
-  const goClarify = useCallback((tile: Tile) => {
-    setClarifier("");
-    setStage({ name: "clarify", tile });
-  }, []);
 
   const goPick = useCallback(() => {
     setStage({ name: "pick" });
@@ -74,23 +70,25 @@ export function TilePickerScreen({ onComplete }: TilePickerScreenProps) {
     setStage({ name: "signin", tile: null, seedMessage: null });
   }, []);
 
-  const finishWithSeed = useCallback(
-    (tile: Tile, clarifier: string) => {
-      const message = composeSeedMessage(tile.id, t(tile.titleKey), clarifier);
-      // Stash the seed to localStorage — ChatPanel picks it up on its
-      // first-fresh-session effect and auto-sends it as the first
-      // chat turn. No sign-in required; the device's anonymous trial
-      // starts when the server sees /events/issue-started.
+  const handlePick = useCallback(
+    (tile: Tile) => {
+      // "Other" has no preset problem — open the chat empty and let the
+      // user describe it there (Noah's empty state prompts "tell me
+      // what's wrong"). No forced textarea.
+      if (tile.id === "other") {
+        onComplete();
+        return;
+      }
+      // Concrete problem → diagnose immediately. Seed the tile's title as
+      // the first turn; ChatPanel auto-sends it on the first fresh session.
+      const message = composeSeedMessage(tile.id, t(tile.titleKey), "");
       try {
         localStorage.setItem(
           "noah.pendingSeed",
-          JSON.stringify({
-            message,
-            expiresAt: Date.now() + 60 * 60 * 1000,
-          }),
+          JSON.stringify({ message, expiresAt: Date.now() + 60 * 60 * 1000 }),
         );
       } catch {
-        // localStorage disabled — the user will type manually, fine.
+        // localStorage disabled — user can type in chat instead, fine.
       }
       onComplete();
     },
@@ -107,20 +105,7 @@ export function TilePickerScreen({ onComplete }: TilePickerScreenProps) {
     );
   }
 
-  if (stage.name === "clarify") {
-    const { tile } = stage;
-    return (
-      <ClarifyStage
-        tile={tile}
-        value={clarifier}
-        onChange={setClarifier}
-        onBack={goPick}
-        onContinue={(text) => finishWithSeed(tile, text)}
-      />
-    );
-  }
-
-  return <PickStage onPick={goClarify} onSignInClick={goSignInBlank} />;
+  return <PickStage onPick={handlePick} onSignInClick={goSignInBlank} />;
 }
 
 // ── Pick stage ────────────────────────────────────────────────────────────
@@ -243,92 +228,6 @@ function PickStage({
               </button>
             </div>
           </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ── Clarify stage ─────────────────────────────────────────────────────────
-
-function ClarifyStage({
-  tile,
-  value,
-  onChange,
-  onBack,
-  onContinue,
-}: {
-  tile: Tile;
-  value: string;
-  onChange: (v: string) => void;
-  onBack: () => void;
-  onContinue: (text: string) => void;
-}) {
-  const { t } = useLocale();
-  // The clarifier is OPTIONAL — picking a tile is already a complete
-  // statement of intent. The button label reflects whether the user
-  // added detail: "Continue" with text, "Diagnose now" without.
-  const hasDetail = value.trim().length > 0;
-  const { Icon } = tile;
-  return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-bg-primary px-6 py-10">
-      <div className="w-full max-w-xl">
-        <button
-          onClick={onBack}
-          className="inline-flex items-center gap-1.5 text-xs text-text-muted hover:text-text-secondary mb-6"
-        >
-          <ArrowLeft size={13} strokeWidth={2} />
-          {t("onboarding.backLabel")}
-        </button>
-
-        <div className="flex items-center gap-3 mb-6">
-          <span
-            className="flex items-center justify-center w-11 h-11 rounded-xl"
-            style={{
-              background: "var(--color-accent-blue-soft)",
-              color: "var(--color-accent-indigo)",
-              border: "1px solid var(--color-accent-border)",
-            }}
-            aria-hidden
-          >
-            <Icon size={22} strokeWidth={1.75} />
-          </span>
-          <h2 className="text-lg font-semibold text-text-primary">
-            {t(tile.titleKey)}
-          </h2>
-        </div>
-
-        <textarea
-          autoFocus
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-              e.preventDefault();
-              onContinue(value.trim());
-            }
-          }}
-          placeholder={t(tile.hintKey)}
-          rows={4}
-          className="w-full px-4 py-3 rounded-xl bg-bg-input border border-border-primary text-base text-text-primary placeholder-text-muted outline-none focus:border-border-focus transition-colors resize-none"
-        />
-        <p className="mt-2 text-[11.5px] text-text-muted">
-          {t("onboarding.clarifierOptional")}
-        </p>
-
-        <div className="mt-4 flex gap-2">
-          <button
-            onClick={onBack}
-            className="px-4 py-2 rounded-xl text-sm text-text-secondary hover:text-text-primary transition-colors"
-          >
-            {t("onboarding.backLabel")}
-          </button>
-          <button
-            onClick={() => onContinue(value.trim())}
-            className="btn-launch flex-1 py-2 rounded-xl text-sm font-medium cursor-pointer"
-          >
-            {hasDetail ? t("onboarding.continue") : t("onboarding.diagnoseNow")}
-          </button>
         </div>
       </div>
     </div>

--- a/apps/desktop/src/golden-path.test.tsx
+++ b/apps/desktop/src/golden-path.test.tsx
@@ -296,11 +296,9 @@ describe("Golden path — second-issue → subscribe → pay", () => {
     ).toBeTruthy();
 
     await user.click(screen.getByText("Wi-Fi or internet issues"));
-    const clarifier = await screen.findByRole("textbox");
-    await user.type(clarifier, "drops every 10 min at home");
-    await user.click(screen.getByText("Continue"));
 
-    // Seed auto-sends → second-issue modal pops in parallel.
+    // Picking a concrete tile diagnoses immediately — the tile title is
+    // the seed, no clarifier step. Seed auto-sends → second-issue modal.
     await waitFor(() => {
       expect(commands.sendMessageV2).toHaveBeenCalled();
     });
@@ -341,11 +339,6 @@ describe("Golden path — second-issue → subscribe → pay", () => {
 
     await screen.findByText(/What's going on with your Mac/);
     await user.click(screen.getByText("My Mac feels slow"));
-    await user.type(
-      await screen.findByRole("textbox"),
-      "Safari lags for ten seconds every new tab",
-    );
-    await user.click(screen.getByText("Continue"));
 
     await screen.findByText(/Keep Noah on your Mac/);
 
@@ -365,11 +358,6 @@ describe("Golden path — second-issue → subscribe → pay", () => {
 
     await screen.findByText(/What's going on with your Mac/);
     await user.click(screen.getByText("Battery drains fast"));
-    await user.type(
-      await screen.findByRole("textbox"),
-      "used to get 8h now I get 3",
-    );
-    await user.click(screen.getByText("Continue"));
 
     await screen.findByText(/Keep Noah on your Mac/);
 

--- a/apps/desktop/src/hooks/useAgent.ts
+++ b/apps/desktop/src/hooks/useAgent.ts
@@ -154,7 +154,14 @@ export function useAgent(): UseAgentReturn {
       }
       if (!ent || ent.status === "none") {
         try {
-          const started = await commands.consumerNotifyIssueStarted();
+          // Pass conversation (session) id + the verbatim opening prompt so
+          // the backend records authoritative user text, not a proxy guess.
+          const started = await commands.consumerNotifyIssueStarted(
+            undefined,
+            originSessionId,
+            undefined,
+            trimmed,
+          );
           if (started) consumer.setEntitlement(started);
         } catch {
           // non-fatal — trial start is best-effort; server is authoritative

--- a/apps/desktop/src/lib/tauri-commands.ts
+++ b/apps/desktop/src/lib/tauri-commands.ts
@@ -557,12 +557,20 @@ export async function consumerGetEntitlement(): Promise<Entitlement | null> {
 
 export async function consumerNotifyIssueStarted(
   tzOffsetMinutes?: number,
+  // Conversation/issue context (all optional, ignored by older servers):
+  // the session id, the generated title, and the verbatim opening prompt.
+  conversationId?: string,
+  title?: string,
+  text?: string,
 ): Promise<Entitlement | null> {
   return await invoke<Entitlement | null>("consumer_notify_issue_started", {
     tzOffsetMinutes:
       typeof tzOffsetMinutes === "number"
         ? tzOffsetMinutes
         : new Date().getTimezoneOffset(),
+    conversationId: conversationId ?? null,
+    title: title ?? null,
+    text: text ?? null,
   });
 }
 
@@ -577,8 +585,14 @@ export async function consumerTrialLinkEmail(email: string): Promise<void> {
   await invoke<void>("consumer_trial_link_email", { email });
 }
 
-export async function consumerNotifyFixCompleted(): Promise<FixCompletedResult | null> {
-  return await invoke<FixCompletedResult | null>("consumer_notify_fix_completed");
+export async function consumerNotifyFixCompleted(
+  conversationId?: string,
+  outcome?: string,
+): Promise<FixCompletedResult | null> {
+  return await invoke<FixCompletedResult | null>("consumer_notify_fix_completed", {
+    conversationId: conversationId ?? null,
+    outcome: outcome ?? null,
+  });
 }
 
 export async function consumerBillingCheckoutUrl(plan: "monthly" | "annual"): Promise<string> {

--- a/apps/desktop/src/lib/tauri-commands.ts
+++ b/apps/desktop/src/lib/tauri-commands.ts
@@ -555,6 +555,12 @@ export async function consumerGetEntitlement(): Promise<Entitlement | null> {
   return await invoke<Entitlement | null>("consumer_get_entitlement");
 }
 
+/** Activation beacon — fired once per launch so an app-open is counted
+ *  even if the user never sends a message. Best-effort. */
+export async function consumerNotifyAppOpen(): Promise<void> {
+  await invoke<void>("consumer_notify_app_open");
+}
+
 export async function consumerNotifyIssueStarted(
   tzOffsetMinutes?: number,
   // Conversation/issue context (all optional, ignored by older servers):

--- a/apps/desktop/src/onboarding.test.tsx
+++ b/apps/desktop/src/onboarding.test.tsx
@@ -341,56 +341,35 @@ describe("Onboarding gate", () => {
 // TilePickerScreen
 // ═══════════════════════════════════════════════════════════════════════════
 
-describe("TilePickerScreen → clarify → seed", () => {
-  it("clicking a tile shows the clarify stage with the tile's title", async () => {
-    const onComplete = vi.fn();
-    const user = userEvent.setup();
-    render(<TilePickerScreen onComplete={onComplete} />);
-    await user.click(screen.getByText("My Mac feels slow"));
-    // Clarify stage echoes the title as a heading
-    expect(
-      screen.getAllByText("My Mac feels slow").length,
-    ).toBeGreaterThan(0);
-    // No detail typed → button reads "Diagnose now" and is enabled
-    // (clicking it seeds the bare category, no clarifier required).
-    // After typing, the same button switches to "Continue".
-    expect(screen.getByText("Diagnose now")).toBeTruthy();
-    const textarea = screen.getByRole("textbox");
-    await user.type(textarea, "a");
-    expect(screen.getByText("Continue")).toBeTruthy();
-  });
-
-  it("stashes a composed seed to localStorage and calls onComplete", async () => {
+describe("TilePickerScreen → diagnose", () => {
+  it("clicking a concrete tile diagnoses immediately — seeds the tile title and calls onComplete, no clarifier", async () => {
     const onComplete = vi.fn();
     const user = userEvent.setup();
     render(<TilePickerScreen onComplete={onComplete} />);
     await user.click(screen.getByText("Wi-Fi or internet issues"));
-    const textarea = screen.getByRole("textbox");
-    await user.type(textarea, "drops every 10 min at home");
-    await user.click(screen.getByText("Continue"));
 
+    // No clarifier screen — picking the tile goes straight to the chat
+    // handoff (no textarea to read as "you must type").
+    expect(screen.queryByRole("textbox")).toBeNull();
     expect(onComplete).toHaveBeenCalledTimes(1);
+
     const stashed = localStorage.getItem("noah.pendingSeed");
     expect(stashed).not.toBeNull();
     const parsed = JSON.parse(stashed!);
-    // Category title prefixed, then user's clarifier
-    expect(parsed.message).toBe(
-      "Wi-Fi or internet issues. drops every 10 min at home",
-    );
+    // Seed is the bare tile title; Noah asks for specifics in-chat.
+    expect(parsed.message).toBe("Wi-Fi or internet issues");
     expect(parsed.expiresAt).toBeGreaterThan(Date.now());
   });
 
-  it("'other' tile preserves the user's raw text without a category prefix", async () => {
+  it("the 'other' tile opens the chat empty — completes with no seed stashed", async () => {
     const onComplete = vi.fn();
     const user = userEvent.setup();
     render(<TilePickerScreen onComplete={onComplete} />);
     await user.click(screen.getByText("Something else"));
-    const textarea = screen.getByRole("textbox");
-    await user.type(textarea, "something weird with Finder");
-    await user.click(screen.getByText("Continue"));
 
-    const parsed = JSON.parse(localStorage.getItem("noah.pendingSeed")!);
-    expect(parsed.message).toBe("something weird with Finder");
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    // No preset problem → nothing auto-sent; user describes it in chat.
+    expect(localStorage.getItem("noah.pendingSeed")).toBeNull();
   });
 
   it("'Already have an account?' routes to the sign-in screen", async () => {
@@ -400,18 +379,6 @@ describe("TilePickerScreen → clarify → seed", () => {
     await user.click(screen.getByText(/Already have an account/));
     // Sign-in prompt comes from i18n en.signIn.prompt
     expect(await screen.findByText("What's your email?")).toBeTruthy();
-  });
-
-  it("Back from clarify returns to the tile grid", async () => {
-    const user = userEvent.setup();
-    render(<TilePickerScreen onComplete={vi.fn()} />);
-    await user.click(screen.getByText("Battery drains fast"));
-    // Use the Back button (there are two — text button and arrow link)
-    const backBtns = screen.getAllByText("Back");
-    await user.click(backBtns[0]);
-    // Grid shows multiple tiles again
-    expect(screen.getByText("My Mac feels slow")).toBeTruthy();
-    expect(screen.getByText("Battery drains fast")).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
Two coherent pieces:

**Telemetry** (3 commits): send conversation id + call-kind on `/v1/messages`; report authoritative title / opening prompt / outcome; fire an app-open activation beacon on launch. Pairs with the noah-consumer growth work.

**Onboarding** (1 commit): a tile pick now goes straight into diagnosis (seeds it as the first chat turn) instead of routing through a full-screen clarifier textarea that read as 'you must type' and bounced first-run users. Tests updated.

**Verified:** clean merge against the paywall work now on main (flag-gated OnboardingFlow + TilePicker coexist), tsc 0 errors, **149 desktop tests + 57 Rust safety tests pass.**